### PR TITLE
feat(write): portable anti-rush craft-core + Director pacing reviewer

### DIFF
--- a/plugins/write/craft/craft-core-universal.md
+++ b/plugins/write/craft/craft-core-universal.md
@@ -1,0 +1,75 @@
+# Draft-Loop Craft Core — SHARED across all profiles
+
+> Shared, content-agnostic craft auto-fails + generative directives inherited by **every** draft-loop profile (rp, hush, future, and every project). The engine (`plugins/write/engines/rp-draft-loop.js`) feeds this file to **every** profile's PROSE/solo drafter (via `SOURCES`) and to the **CRITIC** + **solo self-audit** as scoring rules. It does **not** feed the CONTINUITY agent (these are voice/craft, not continuity). Profile rubrics (a project's `reference_<mode>_draft_loop_rubric.md`) carry domain-specific rules **in addition** to these. On any conflict, the stricter rule wins.
+>
+> **Portable:** this file ships with the asha `write` plugin. A project's mode manifest binds `slots.craftCore` to it (conventionally `${asha}/craft/craft-core-universal.md`), so every project inherits the same universal craft layer; the project supplies only its profile-specific rubric, voice, and bible.
+
+These are **content-agnostic**. They describe *how prose manages tension, state, and pacing* — not *what it is about* — so they apply to RP beats, novel passages, romance, literary fiction, anything.
+
+---
+
+## CRITIC auto-fails — universal (any one = FAIL)
+
+### Tension / resolution
+
+- **`both_true_resolution`** — A beat resolves its tension by asserting opposed truths hold *simultaneously*: "X and Y at once," "both true," "and it always would be," "the tenderness and the cruelty in the same breath," "real and impossible at the same time." **Trigger:** used as a **beat-closer**, OR more than **once per scene**. Contradiction belongs *across* beats, not blended within one. **Fix:** let ONE thing stand in the moment; put its opposite in a different beat and let the reader hold both. (Genuine ambivalence rendered *once* and *earned* is allowed — this targets the habit, not the tool.)
+
+- **`narrated_contradiction`** *(dialogue)* — A character states or explains their own paradox, motive, or both-sidedness aloud: "I love you and I'm the one doing this to you," "I'm cruel to you because I care." **Why it fails:** self-narrated contradiction reads as self-exculpation / bad faith — the character performing a stable position instead of living an unstable one. **Fix:** cut the explanation. The character commits to the present feeling, fully; the contradiction shows in the *gap* between this line and a later, opposite action — never spoken.
+
+- **`editorializing_close`** — A beat ends on an interpretive / summary sentence that reconciles or explains what just happened ("and that was the whole of it," "which was love, and was also a cage," "he understood then that…"), instead of ending on the concrete, the action, or the cut. **Fix:** end on the image, the act, the line, or nothing. Reconciling is the reader's job. (This also catches narrator hedging — stepping out to frame the material as it lands.)
+
+### Pacing / rushing — the anti-rush family
+
+> The single most common failure: once the writer sees where a beat is going, the prose-drive toward resolution compresses the journey and "lands" the idea instead of *living in the approach.* Tension dies because the ending was shown early. These catch it.
+
+- **`telegraphed_destination`** — The outcome is pre-narrated — named, foreshadowed sentimentally, or shown in setup/exposition — so the reader/player sees the ending before the approach is traversed ("she knew where this was going," "it would end the way these things end," the narrator gesturing at the payoff before it arrives). **Why it fails:** a destination shown is a destination spent; nothing is left to dread or discover. **Fix:** withhold the destination entirely; render only the present step, and let the arrival, when it comes, *be* the first time it's seen.
+
+- **`arrived_not_approached`** — The prose jumps to the payoff (the climax, the realization, the transformation, the capitulation) without traversing the path to it — a state or sensation escalates with no graduated build, the moment delivered whole instead of approached. **Why it fails:** the payoff is unearned and the reader is a spectator to a result, not a participant in a process. **Fix:** render the approach in increments and **stop short of the arrival**; the payoff is a *later* beat.
+
+- **`rushed_increment`** — Multiple distinct steps that each deserve their own beat are compressed into one — build and climax in the same breath, three escalations summarized as one, a process collapsed to its outcome ("arms, pants, done"). **Why it fails:** each step the reader doesn't get to inhabit is a step of tension thrown away. **Fix:** break the compression apart; give each genuine increment its own dwell.
+
+- **`dwell_deficit`** *(profile sets severity)* — A high-stakes moment is given far fewer words / beats than its weight demands — a key beat skimmed (e.g. under ~½ the length of comparable moments in the same work), a turning point passed over in a sentence. **Why it fails:** the prose advances when it should deepen; the reader has no time to land in the state before the next push. **Fix:** weight the words to the moment; let the important beat be long and slow.
+
+---
+
+## Craft rules — universal definition, profile sets the severity
+
+These failures are shared across profiles; the **definition lives here** (maintained once), but whether a profile treats one as auto-fail or minor is set in that profile's rubric, which also carries the domain-specific instance and detection.
+
+- **`exposition_control`** — Backstory, mechanism, cosmology, or world-info delivered as a *block*, an *announcement*, or a *gloss/decode*, instead of surfaced through action / object / friction — or left withheld where withholding is the design. **Fix:** install it through routine and let it be discovered; never declare it. *(Profile instances: RP `exposition_dump` — the cultivation announced; Hush `exposition_decode` — the cosmology / untranslated German glossed.)*
+- **`abstract_sensation`** — An emotion, sensation, or action met with a *named label* ("he felt X," "it activates," "responds," "violated") instead of a specific *rendered* concrete. **Fix:** render the physical particular; cut the label. *(Profile instances: RP `abstract_body_response`; Hush minor "slack abstraction where a concrete image was available.")*
+- **`uniform_rhythm`** — Sentence rhythm flattened: uniform length and shape, no variance; at the structural extreme, smooth even beat-architecture (the GPTZero template). **Fix:** vary length and shape — a long clause against a one-word line; break the even cadence. *(Profile instances: RP minor `uniform_rhythm`; Hush auto-fail `rhythm_flatness`.)*
+
+---
+
+## Generative directives — universal (for the PROSE / solo drafter)
+
+- **Pacing intent first — approach, don't arrive.** Before drafting, fix the pacing intent: name where this beat is *going*, then render only the **approach** and **stop short of it.** The payoff is earned across beats, never delivered in one. When you can see the destination, that is the signal to slow down, not speed up — the destination is the thing you withhold.
+- **Default to DEEPEN, not ADVANCE.** A player turn / a new line is a reason to go *deeper into the present moment* by default — more sensation, more friction, more of what is already happening — unless it explicitly pushes the situation forward. Advancing the plot is the exception; dwelling is the rule. (Match the *unit*: in interactive RP, one input usually deepens one beat — do not consume three steps of the arc in one reply.)
+- **Singular states, sequenced.** In any beat a character occupies *one* state fully, and it may exclude its opposite. Range and movement come from traversing distinct states *across* beats — contradiction across time, not superposition.
+- **Watch for the fixed point.** If every beat lands in the same emotional resolution regardless of what happens in it, the state-space has collapsed and the prose is dead however violent the events. Vary the landing; let beats end badly and *stay* there.
+- **Falseness is load-bearing.** Allow lies that stay lies, hopes that are wrong, losses that are total, moments that are only one thing. If nothing can be false, nothing is at stake.
+- **Reconciling is the reader's job.** Render singular scenes and trust accumulation. Don't state the paradox; don't footnote the beat.
+
+---
+
+## Profile mapping (reference)
+
+Single source of truth for each universal kernel; the profile rubrics keep the domain instance, detection, and severity, and point back here. The rows below document the AAS reference profiles (rp, hush) as the worked example; a new project adds its own profile rows in its own rubric.
+
+| Core rule | RP category | Hush category |
+|---|---|---|
+| `both_true_resolution` | (enforced via core) | cf. `tautological_recursion` |
+| `narrated_contradiction` | (enforced via core) | cf. `tautological_recursion` |
+| `editorializing_close` | (enforced via core) | cf. `resolution_creep` (related, not identical) |
+| `telegraphed_destination` | (enforced via core; RP detection in rubric) | (enforced via core) |
+| `arrived_not_approached` | (enforced via core; RP detection in rubric) | (enforced via core) |
+| `rushed_increment` | (enforced via core; RP detection in rubric) | (enforced via core) |
+| `dwell_deficit` | RP detection in rubric (severity) | (enforced via core) |
+| `exposition_control` | `exposition_dump` | `exposition_decode` |
+| `abstract_sensation` | `abstract_body_response` | "slack abstraction" (minor) |
+| `uniform_rhythm` | `uniform_rhythm` (minor) | `rhythm_flatness` (auto-fail) |
+
+**Deliberately NOT migrated (stays profile-specific):** RP `tic_density` (literal substring scan — the tuning is the specificity), `tag_word_labeling`, `smooth_at_recognition`, `telegraphing`, and `flatness_engine` (a *dramatic-stakes* rule — **not** merged with Hush's rhythm flatness); Hush `register_break`, `tautological_recursion`, `resolution_creep`.
+
+> **Pacing note:** the anti-rush auto-fails above are the *hard floor* (any one = FAIL). The richer pacing assessment — dwell weighting, texture, state-settling — is the job of the optional **Director reviewer** (`plugins/write/craft/director-rubric.md`), enabled per-manifest via `slots.directorRubric`.

--- a/plugins/write/craft/director-rubric.md
+++ b/plugins/write/craft/director-rubric.md
@@ -1,0 +1,33 @@
+# Director Rubric — pacing / dwell (SHARED across all profiles)
+
+> The scoring spec for the optional **DIRECTOR** reviewer in the draft-loop gate. Content-agnostic — it judges *how a beat is paced*, not what it is about. Ships with the asha `write` plugin; a project enables it by binding `slots.directorRubric` in its mode manifest (conventionally `${asha}/craft/director-rubric.md`). When the slot is absent, the Director does not run (zero cost).
+>
+> The Director exists to separate *deciding how a scene should pace* from *generating the prose* — so the drafter's pull toward resolution cannot quietly override good pacing. It is the dedicated counter to **rushing**: the most common failure, where the writer sees the destination and races to it. The Director's bias is always toward **slower** — toward dwelling, withholding the payoff, and giving the important moment its weight.
+
+## What the Director reads
+
+The DRAFT under review, plus the scene context (for what the beat is *for*, its place in the arc, and the relative weight of comparable beats already on the page). It does **not** re-judge voice, continuity, or canon — those are the Critic's and Continuity's jobs. The Director judges **pacing only.**
+
+## Scoring
+
+Return `{ pass, violations: [{category, severity, quote, why, fix}], revision_directive }`. **PASS only if zero auto-fail violations.** Be adversarial about speed: if the beat feels efficient, satisfying, or "lands the idea" cleanly, suspect rushing. A beat that dwells, withholds, and leaves the reader *wanting the next step* is passing; a beat that delivers the next step is usually failing.
+
+### Auto-fail (any one = FAIL)
+
+| Category | What it is | Detection / fix |
+|---|---|---|
+| `rush_to_climax` | The beat reaches its payoff — the climax, reveal, capitulation, transformation, or release — instead of approaching it. The destination is *arrived at* within this beat. | The beat ends on (or passes through) the thing it was building toward. **Fix:** cut the beat off *before* the payoff; render only the step before it. The arrival is a later beat. |
+| `texture_skim` | Sensory / embodied detail is compressed or summarized where the moment wanted inhabiting — the reader is told a thing happened rather than given time inside it ("arms, pants, done"; "and then it was over"). | Summary verbs and elision over a moment of weight. **Fix:** slow to the particular — render the increments of sensation/action the summary skipped. |
+| `pacing_mismatch` | Beat length is out of phase with narrative weight: a high-stakes moment given a sentence, or low-stakes connective tissue given paragraphs. | Compare the beat's length to comparable beats in the context. A turning point markedly *shorter* than ordinary beats is the common case. **Fix:** weight the words to the moment — expand the important, compress the connective. |
+| `state_surface` | A new state (an emotion, a body-state, a power shift) is introduced and immediately built upon, with no beat for it to *settle* — the reader never adjusts to state N before state N+1 arrives. | Two state-changes stacked with no dwell between. **Fix:** hold on the new state; let it be the whole of one beat before anything pushes past it. |
+
+### Minor (note, don't necessarily fail)
+
+- `dwell_deficit` — the beat is adequately paced but a specific moment within it could carry more weight; flag the spot.
+- `momentum_loss` — the rare opposite: genuine dwelling has tipped into stalling / repetition with no new texture. (Use sparingly — the default failure is rushing, not stalling. Do not invoke this to license speeding up; invoke it only when a beat repeats the *same* texture with nothing added.)
+
+## Revision directive
+
+If it fails, write `revision_directive` as one concrete paragraph the Prose agent can act on — name the exact payoff to withhold, the increment to render instead, and where to cut the beat short. Always push toward *slower and earlier*: "stop the beat before X; render only the approach to it; the arrival is the next beat."
+
+> The Director never asks for speed. Its only verdict directions are *dwell more, withhold the payoff, cut the beat earlier, weight the words to the moment.*

--- a/plugins/write/engines/README.md
+++ b/plugins/write/engines/README.md
@@ -13,8 +13,10 @@ via `args.profileConfig` (a resolved *mode manifest*).
 ```
 draft (Prose agent)
   ├─ mode:"solo"  → one agent drafts + self-audits against the profile, returns. (cheap default)
-  └─ mode:"gate"  → Prose ─▶ (Critic ‖ Continuity) score in parallel ─▶ revise ─▶ re-score
+  └─ mode:"gate"  → Prose ─▶ (Critic ‖ Continuity ‖ Director?) score in parallel ─▶ revise ─▶ re-score
                     cap at maxIterations (default 3). (scrutiny tier)
+                    Director runs only when profileConfig.directorRubric is set — a pacing /
+                    anti-rush reviewer; absent = not run (zero cost). All reviewers must PASS to converge.
 ```
 
 Output stays in the caller's chat. The engine **never writes to a manuscript or canon file**.
@@ -40,7 +42,10 @@ Output stays in the caller's chat. The engine **never writes to a manuscript or 
   unit,                 // what one draft produces ("GM-voice RP scene beat", "prose passage")
   rubric,               // ABS path: profile-specific craft rubric (auto-fails + scoring)
   voiceSpec,            // ABS path: voice authority
-  craftCore,            // ABS path: SHARED craft-core (universal auto-fails) — same across modes
+  craftCore,            // ABS path: SHARED craft-core (universal auto-fails + pacing/anti-rush) — same across modes
+                        //   conventionally ${asha}/craft/craft-core-universal.md (ships with this plugin)
+  directorRubric,       // OPTIONAL ABS path: enables the Director (pacing/anti-rush) reviewer in gate mode
+                        //   conventionally ${asha}/craft/director-rubric.md (ships with this plugin)
   continuityAuthority,  // ABS path: continuity/state authority
   bible,                // ABS path(s): character/world canon (string; multiple joined ' + ')
   context,              // ABS path: starting scene/state file
@@ -68,13 +73,14 @@ All paths must be **absolute** (the engine has no filesystem access and does no 
    | `mode`, `label`, `unit`, `defaultRunMode` | same |
    | `slots.craftRubric` | `rubric` |
    | `slots.voiceSpec` | `voiceSpec` |
-   | `slots.craftCore` | `craftCore` |
+   | `slots.craftCore` | `craftCore` (conventionally `${asha}/craft/craft-core-universal.md`) |
+   | `slots.directorRubric` | `directorRubric` (OPTIONAL; conventionally `${asha}/craft/director-rubric.md`) |
    | `slots.continuityAuthority` | `continuityAuthority` |
    | `slots.bible` (string or list) | `bible` (list → `'"a" + "b"'`) |
    | `slots.context` | `context` |
    | `models.reviewer` | `reviewerModel` |
    | `models.draft` | `draftModel` |
-   | (every `${mem}`/`${vault}` token) | substituted from `roots` to an absolute path |
+   | (every `${mem}`/`${vault}`/`${asha}` token) | substituted from `roots` to an absolute path |
 
    `extensions.*` (the live-interactive layer) is **not** consumed by this engine.
 4. **Invoke**:
@@ -83,10 +89,27 @@ All paths must be **absolute** (the engine has no filesystem access and does no 
               args: { profileConfig: <resolved>, beatBrief: '…', mode: 'gate' } })
    ```
 
+## Shared craft layer (ships with this plugin)
+
+`plugins/write/craft/` holds the **generic, portable** craft files, fed to every profile:
+
+- `craft-core-universal.md` — universal CRITIC auto-fails (tension/resolution + the **pacing / anti-rush
+  family**: `telegraphed_destination`, `arrived_not_approached`, `rushed_increment`, `dwell_deficit`),
+  shared craft rules, and the generative directives (incl. *pacing-intent-first / approach-don't-arrive*).
+  Fed to every profile's Prose/solo drafter (via `SOURCES`) and to the Critic + solo self-audit. **Not** fed
+  to Continuity. A profile rubric adds domain-specific detection **on top**.
+- `director-rubric.md` — the optional **Director**'s pacing scoring (enabled per-manifest via
+  `slots.directorRubric`).
+
+Projects inherit the whole layer by adding an `asha:` root to the manifest's `roots`
+(`asha: <ASHA_ROOT>/plugins/write`) and pointing `slots.craftCore` / `slots.directorRubric` at
+`${asha}/craft/...`. A new project gets the universal craft + Director for free; it supplies only its
+own profile rubric, voice, and bible.
+
 ## Return value
 
 `solo`: `{ beat, profile, mode:"solo", selfCaught[] }`
-`gate`: `{ beat, profile, converged, rounds, finalCriticPass, finalContinuityPass, caughtAndFixed[], unresolved[], critic, continuity }`
+`gate`: `{ beat, profile, converged, rounds, finalCriticPass, finalContinuityPass, finalDirectorPass?, caughtAndFixed[], unresolved[], critic, continuity, director? }` — `finalDirectorPass`/`director` present only when the Director ran (`directorRubric` set).
 On no-output: `{ beat:null, …, error|unresolved }`.
 
 ## Notes

--- a/plugins/write/engines/rp-draft-loop.js
+++ b/plugins/write/engines/rp-draft-loop.js
@@ -40,6 +40,8 @@ const maxRounds = a.maxIterations || 3
 const mode = a.mode || P.defaultRunMode || 'gate' // 'solo' = one agent draft + self-audit (cheap); 'gate' = independent Critic+Continuity loop (scrutiny)
 const reviewerModel = a.reviewerModel || P.reviewerModel || 'sonnet' // gate reviewers grade an explicit checklist — cheaper than the drafter
 const draftModel = a.draftModel || P.draftModel || null // null = inherit the session model for drafting
+const directorRubric = P.directorRubric || null // OPTIONAL: when bound, a 3rd parallel reviewer scores pacing/dwell (the anti-rush Director); absent = not run (zero cost)
+const hasDirector = !!directorRubric
 const draftOpts = (label, phase) => {
   const o = { label, phase, schema: PROSE_SCHEMA }
   if (draftModel) o.model = draftModel
@@ -77,7 +79,7 @@ Follow the PROSE directives in your rubric EXACTLY; render in the voice spec's r
 BRIEF:
 ${brief}
 
-SELF-AUDIT (do this silently, then return only the corrected prose): check your draft against every CRITIC auto-fail and CONTINUITY category named in your rubric AND the shared craft-core — POV / psychic-awareness, canon speech & voice-budgets, telegraphing, verbal tics, exposition-dump, failure-to-advance, invented mechanics, setting / locked-beat breaks, softened stakes, flatness, AND the universal craft auto-fails (both_true_resolution, narrated_contradiction, editorializing_close) — and rewrite to eliminate each.
+SELF-AUDIT (do this silently, then return only the corrected prose): check your draft against every CRITIC auto-fail and CONTINUITY category named in your rubric, AND every universal auto-fail defined in the shared craft-core — its tension/resolution rules, its pacing / anti-rush family (telegraphed destination, arrived-not-approached, rushed increment, dwell deficit), and its shared craft rules — plus POV / psychic-awareness, canon speech & voice-budgets, telegraphing, verbal tics, exposition-dump, failure-to-advance, invented mechanics, setting / locked-beat breaks, softened stakes, flatness — and rewrite to eliminate each.
 
 Return: \`beat\` = ONLY the finished, self-corrected prose (no preamble/headers/notes; do NOT write to any file); \`selfCaught\` = a short list of issues you caught and fixed (one short phrase each, e.g. "pov: cut 'he decides'"), or [] if none.`
 }
@@ -125,7 +127,7 @@ const PROSE_SCHEMA = {
 }
 
 function criticPrompt(draft) {
-  return `You are the CRITIC agent for ${P.label}. Read the shared craft-core (${CORE}), your rubric (${P.rubric}), and voice spec (${P.voiceSpec}). Score the DRAFT below against BOTH the CRITIC section of your rubric AND every auto-fail in the shared craft-core (voice/register, mechanical/telegraphic phrasing, exposition density, the universal auto-fails — both_true_resolution, narrated_contradiction, editorializing_close — and any profile-specific auto-fails). Be adversarial — assume flaws exist; if your first pass finds nothing, look again. PASS only per your rubric's stated thresholds. Quote the offending text verbatim and give a concrete fix in each violation. If it passes, return pass=true with empty violations and empty revision_directive; if it fails, write revision_directive as one concrete paragraph the Prose agent can act on.
+  return `You are the CRITIC agent for ${P.label}. Read the shared craft-core (${CORE}), your rubric (${P.rubric}), and voice spec (${P.voiceSpec}). Score the DRAFT below against BOTH the CRITIC section of your rubric AND every auto-fail defined in the shared craft-core (voice/register, mechanical/telegraphic phrasing, exposition density, the tension/resolution rules, the pacing / anti-rush family, the shared craft rules, and any profile-specific auto-fails). Be adversarial — assume flaws exist; if your first pass finds nothing, look again. PASS only per your rubric's stated thresholds. Quote the offending text verbatim and give a concrete fix in each violation. If it passes, return pass=true with empty violations and empty revision_directive; if it fails, write revision_directive as one concrete paragraph the Prose agent can act on.
 
 DRAFT:
 """
@@ -135,6 +137,15 @@ ${draft}
 
 function continuityPrompt(draft) {
   return `You are the CONTINUITY agent for ${P.label}. Read your continuity authority (${P.continuityAuthority}), your rubric (${P.rubric}), the bible/character canon (${P.bible}), and the scene context (${ctxFile} — including any LOCKED beat in its comment-block). Score the DRAFT below against the CONTINUITY categories DEFINED IN YOUR PROFILE RUBRIC ONLY. PASS only if there are zero violations. Quote the offending text verbatim and give a concrete fix. If it passes, return pass=true with empty violations and empty revision_directive; if it fails, write revision_directive as one concrete paragraph the Prose agent can act on.
+
+DRAFT:
+"""
+${draft}
+"""`
+}
+
+function directorPrompt(draft) {
+  return `You are the DIRECTOR agent for ${P.label} — the dedicated PACING reviewer. Read your director rubric (${directorRubric}) and the scene context (${ctxFile} — for the beat's place in the arc and the weight of comparable beats). Judge the DRAFT below for PACING / RUSHING ONLY, against the categories in your director rubric. Do NOT judge voice, continuity, or canon — those are other agents' jobs. Be adversarial about speed: if the beat "lands the idea" cleanly or feels efficient, suspect rushing. PASS only if it dwells appropriately and WITHHOLDS its payoff — the destination must not be reached or telegraphed inside this beat. If it fails, write revision_directive as one concrete paragraph that pushes SLOWER and EARLIER: name the payoff to withhold, the increment to render instead, and where to cut the beat short.
 
 DRAFT:
 """
@@ -164,45 +175,56 @@ if (!draft) {
 // ---- iterate: score in parallel, redraft on failure, cap at maxRounds ----
 let crit = null
 let cont = null
+let dir = null
 let round = 0
 const caughtLog = []
 
 for (round = 1; round <= maxRounds; round++) {
-  const [c, k] = await parallel([
+  const reviewers = [
     () => agent(criticPrompt(draft), { label: `critic:${profileKey}:r${round}`, phase: 'Review', schema: VERDICT_SCHEMA, model: reviewerModel }),
     () => agent(continuityPrompt(draft), { label: `continuity:${profileKey}:r${round}`, phase: 'Review', schema: VERDICT_SCHEMA, model: reviewerModel }),
-  ])
+  ]
+  if (hasDirector) {
+    reviewers.push(() => agent(directorPrompt(draft), { label: `director:${profileKey}:r${round}`, phase: 'Review', schema: VERDICT_SCHEMA, model: reviewerModel }))
+  }
+  const [c, k, d] = await parallel(reviewers)
   crit = c
   cont = k
+  dir = d || null
 
   const critPass = !!(c && c.pass)
   const contPass = !!(k && k.pass)
+  const dirPass = hasDirector ? !!(d && d.pass) : true
   const critViol = (c && c.violations) || []
   const contViol = (k && k.violations) || []
-  log(`[${profileKey}] Round ${round}: critic ${critPass ? 'PASS' : 'FAIL'} (${critViol.length} viol), continuity ${contPass ? 'PASS' : 'FAIL'} (${contViol.length} viol)`)
+  const dirViol = (d && d.violations) || []
+  log(`[${profileKey}] Round ${round}: critic ${critPass ? 'PASS' : 'FAIL'} (${critViol.length} viol), continuity ${contPass ? 'PASS' : 'FAIL'} (${contViol.length} viol)${hasDirector ? `, director ${dirPass ? 'PASS' : 'FAIL'} (${dirViol.length} viol)` : ''}`)
 
-  if (critPass && contPass) break
+  if (critPass && contPass && dirPass) break
 
   critViol.forEach((v) => caughtLog.push(`critic:${v.category}`))
   contViol.forEach((v) => caughtLog.push(`continuity:${v.category}`))
+  dirViol.forEach((v) => caughtLog.push(`director:${v.category}`))
 
   if (round < maxRounds) {
     const directive = [
       !critPass && c ? `CRITIC fixes required:\n${c.revision_directive || critViol.map((v) => `- ${v.category}: ${v.fix}`).join('\n')}` : '',
       !contPass && k ? `CONTINUITY fixes required:\n${k.revision_directive || contViol.map((v) => `- ${v.category}: ${v.fix}`).join('\n')}` : '',
+      !dirPass && d ? `DIRECTOR (pacing) fixes required:\n${d.revision_directive || dirViol.map((v) => `- ${v.category}: ${v.fix}`).join('\n')}` : '',
     ].filter(Boolean).join('\n\n')
     const revObj = await agent(prosePrompt(directive), draftOpts(`prose:revise:${profileKey}:r${round}`, 'Revise'))
     draft = revObj && revObj.beat
     if (!draft) {
-      return { beat: null, profile: profileKey, converged: false, rounds: round, unresolved: ['prose agent returned nothing on revision'], critic: crit, continuity: cont }
+      return { beat: null, profile: profileKey, converged: false, rounds: round, unresolved: ['prose agent returned nothing on revision'], critic: crit, continuity: cont, director: dir }
     }
   }
 }
 
-const converged = !!(crit && crit.pass && cont && cont.pass)
+const converged = !!(crit && crit.pass && cont && cont.pass && (!hasDirector || (dir && dir.pass)))
 const finalUnresolved = []
 ;((crit && crit.violations) || []).forEach((v) => finalUnresolved.push(`critic:${v.category}`))
 ;((cont && cont.violations) || []).forEach((v) => finalUnresolved.push(`continuity:${v.category}`))
+;((dir && dir.violations) || []).forEach((v) => finalUnresolved.push(`director:${v.category}`))
 const uniq = (arr) => arr.filter((x, i) => arr.indexOf(x) === i)
 
 return {
@@ -212,8 +234,10 @@ return {
   rounds: round > maxRounds ? maxRounds : round,
   finalCriticPass: !!(crit && crit.pass),
   finalContinuityPass: !!(cont && cont.pass),
+  finalDirectorPass: hasDirector ? !!(dir && dir.pass) : undefined,
   caughtAndFixed: uniq(caughtLog),
   unresolved: converged ? [] : uniq(finalUnresolved),
   critic: crit,
   continuity: cont,
+  director: hasDirector ? dir : undefined,
 }


### PR DESCRIPTION
## What

Makes the RP/prose **pacing / anti-rush** capability live in asha (portable across projects) and adds an optional **Director** pacing reviewer to the draft-loop gate.

Motivated by the recurring craft failure: *rushing* — once the destination is in view, racing to it and "landing the idea" instead of dwelling in the approach.

## Changes (`plugins/write/`)

- **NEW `craft/craft-core-universal.md`** — the shared, content-agnostic craft-core relocated out of a project's memory into the plugin so it ships with asha. Adds the **pacing / anti-rush auto-fail family**: `telegraphed_destination`, `arrived_not_approached`, `rushed_increment`, `dwell_deficit`, plus a *pacing-intent first / approach-don't-arrive / deepen-not-advance* generative directive. (Existing universal rules + de-dup'd kernels preserved verbatim.)
- **NEW `craft/director-rubric.md`** — the optional Director's pacing scoring spec (`rush_to_climax`, `texture_skim`, `pacing_mismatch`, `state_surface`; bias always toward slower/withhold).
- **`engines/rp-draft-loop.js`** — optional **Director** reviewer: a 3rd parallel reviewer (alongside Critic ‖ Continuity) enabled per-manifest via `profileConfig.directorRubric`; **zero cost when omitted**. All reviewers must PASS to converge; `finalDirectorPass`/`director` added to the gate return. Inline auto-fail references made generic (cite "the shared craft-core" rather than naming rules) so the craft-core is the single source of truth — new rules need no engine edit. Engine stays path-free.
- **`engines/README.md`** — documents the `craft/` layer, the `directorRubric` slot, the `${asha}` root convention, and the updated gate return.

## Portability

Projects inherit the whole craft + Director layer by adding an `asha:` root to their mode manifest and pointing `slots.craftCore` / `slots.directorRubric` at `${asha}/craft/...`. A new project supplies only its own profile rubric, voice, and bible.

## Test plan

- [x] `node --check plugins/write/engines/rp-draft-loop.js` — clean
- [x] Director wiring present (config parse, `directorPrompt`, conditional parallel push, pass-gating, revision-directive, return fields)
- [x] Consuming-project manifests parse; `craftCore`/`directorRubric`/`asha` root resolve to existing files
- [ ] Live gate run (fresh session, registry re-scan): confirm a 3rd `director:*` reviewer fires in parallel and FAILS a deliberately rushed draft, forcing a slow-down redraft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EXVKLQQ479XbCnmSjqv7v
