### PR TITLE
fix(doctor): avoid false FAIL 0 count on macOS

### DIFF
--- a/bin/asha-drift-check.sh
+++ b/bin/asha-drift-check.sh
@@ -334,8 +334,8 @@ fi
 # No residual ${CLAUDE_PLUGIN_ROOT} in plugin command/skill/agent markdown
 # (symlinked verbatim, so a placeholder there would reach the model unported).
 # Excludes docs/ — design docs legitimately show the hooks.json placeholder.
-n="$(grep -rn 'CLAUDE_PLUGIN_ROOT' "$ASHA/plugins" --include='*.md' --exclude-dir=docs 2>/dev/null | wc -l)"
-if [[ "$n" == "0" ]]; then
+n="$(grep -rn 'CLAUDE_PLUGIN_ROOT' "$ASHA/plugins" --include='*.md' --exclude-dir=docs 2>/dev/null | wc -l | tr -d '[:space:]')"
+if [[ "$n" -eq 0 ]]; then
   pass "no CLAUDE_PLUGIN_ROOT in plugin markdown"
 else
   nope "$n CLAUDE_PLUGIN_ROOT refs remain in plugin markdown:"


### PR DESCRIPTION
## Summary
Fixes a portability bug in `bin/asha-drift-check.sh` where `wc -l` output was compared as a raw string.

On macOS/BSD, padded whitespace from `wc -l` caused a false failure in healthy installs:

```
FAIL         0 CLAUDE_PLUGIN_ROOT refs remain in plugin markdown:
```

## Changes
- Trim whitespace from the count with `tr -d '[:space:]'`
- Switch to numeric comparison (`-eq 0`)

## Validation
- `bash tests/test-build-copilot.sh`
- `bash tests/test-init-repo.sh`
- `bash tests/test-doctor.sh`

All pass after this change.

Fixes #6.
