### PR TITLE
Resolve save drift, memory recall, and macOS doctor issues

### DIFF
--- a/bin/asha-drift-check.sh
+++ b/bin/asha-drift-check.sh
@@ -196,8 +196,8 @@ check_generated_agents() { # agents_dir label ext fix_fn
 
 # ── Shared command-skill coverage check (codex + copilot) ──
 # Every plugin command MD (except output-styles) should have a SKILL.md under
-# <skills_dir>/<name>/. Generated files are checked for freshness via mtime
-# (--fix regenerates from source); legacy symlinked SKILL.md must resolve to
+# <skills_dir>/<name>/. Generated files are checked against deterministic
+# rendered bytes (--fix regenerates from source); legacy symlinked SKILL.md must resolve to
 # the source; a whole-dir symlink collision (plugin skill claims the name) is
 # an accepted skip.
 check_command_skills() { # skills_dir label fix_fn
@@ -334,8 +334,8 @@ fi
 # No residual ${CLAUDE_PLUGIN_ROOT} in plugin command/skill/agent markdown
 # (symlinked verbatim, so a placeholder there would reach the model unported).
 # Excludes docs/ — design docs legitimately show the hooks.json placeholder.
-n="$(grep -rn 'CLAUDE_PLUGIN_ROOT' "$ASHA/plugins" --include='*.md' --exclude-dir=docs 2>/dev/null | wc -l)"
-if [[ "$n" == "0" ]]; then
+n="$(grep -rn 'CLAUDE_PLUGIN_ROOT' "$ASHA/plugins" --include='*.md' --exclude-dir=docs 2>/dev/null | wc -l | tr -d '[:space:]')"
+if [[ "$n" -eq 0 ]]; then
   pass "no CLAUDE_PLUGIN_ROOT in plugin markdown"
 else
   nope "$n CLAUDE_PLUGIN_ROOT refs remain in plugin markdown:"

--- a/harnesses/claude.sh
+++ b/harnesses/claude.sh
@@ -175,6 +175,9 @@ claude_install_hooks() {
           value: (
             .value
             | map(
+                select(((._asha_harnesses // ["claude"]) | index("claude")) != null)
+                | del(._asha_harnesses)
+                |
                 .hooks |= map(
                   . + {
                     command: (.command | gsub("\\$\\{CLAUDE_PLUGIN_ROOT\\}"; $root)),

--- a/harnesses/codex.sh
+++ b/harnesses/codex.sh
@@ -502,6 +502,9 @@ for event, groups in events.items():
         dropped.append(event); continue
     if not isinstance(groups, list): continue
     for grp in groups:
+        harnesses = grp.get("_asha_harnesses")
+        if harnesses is not None and "codex" not in harnesses:
+            continue
         matcher = grp.get("matcher")
         if matcher == "*": matcher = None
         for h in grp.get("hooks", []):

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -467,6 +467,9 @@ register_hooks() {
             value: (
               .value
               | map(
+                  select(((._asha_harnesses // ["claude"]) | index("claude")) != null)
+                  | del(._asha_harnesses)
+                  |
                   .hooks |= map(
                     . + {
                       command: (.command | gsub("\\$\\{CLAUDE_PLUGIN_ROOT\\}"; $root)),
@@ -573,6 +576,7 @@ bootstrap_identity() {
     [[ -f "$asha_home/communicationStyle.md" ]] || [[ ! -f "$tmpl_dir/communicationStyle.md" ]] || say "  IDENTITY  would create $asha_home/communicationStyle.md"
     [[ -f "$asha_home/keeper.md" ]]   || say "  IDENTITY  would create $asha_home/keeper.md"
     [[ -f "$asha_home/config.json" ]] || say "  IDENTITY  would create $asha_home/config.json"
+    [[ -f "$asha_home/recall_fixtures.yaml" ]] || [[ ! -f "$tmpl_dir/recall_fixtures.yaml" ]] || say "  IDENTITY  would create $asha_home/recall_fixtures.yaml"
     return 0
   fi
 
@@ -646,6 +650,12 @@ KEEPER_EOF
 }
 CONFIG_EOF
     say "Created ~/.asha/config.json"
+  fi
+
+  # recall_fixtures.yaml — seed once; fixture curation is user-owned thereafter.
+  if [[ ! -f "$asha_home/recall_fixtures.yaml" ]] && [[ -f "$tmpl_dir/recall_fixtures.yaml" ]]; then
+    cp "$tmpl_dir/recall_fixtures.yaml" "$asha_home/recall_fixtures.yaml"
+    say "Created ~/.asha/recall_fixtures.yaml"
   fi
 }
 

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -67,6 +67,7 @@ This plugin does not create persona files — install a persona plugin (e.g., `a
 | `operation.md` | Operational quality rules | When rules evolve |
 | `learnings/` | Patterns from experience (OKF concept bundle) | Via `/session:save` |
 | `config.json` | Settings | When config changes |
+| `recall_fixtures.yaml` | Cross-project question -> memory retrieval checks | With diagnosed-failure memories |
 
 ### Per-project (`Memory/`)
 
@@ -101,8 +102,8 @@ This plugin does not create persona files — install a persona plugin (e.g., `a
 
 | Hook | Purpose |
 |------|---------|
-| SessionStart | Load operation.md + learnings hot tier; conditionally load persona files |
-| PreToolUse | Guardrails — `block-secrets` (deny secret-file access) + `policy-guard` (declarative deny/ask/`max_per_session` rules from `policies/rules.json` + `~/.asha/policies.json`, backed by session_state). Per-harness enforcement reach → [docs/harness-enforcement.md](../../docs/harness-enforcement.md) |
+| SessionStart | Load operation.md + learnings hot tier; conditionally load persona files; build Claude's compact memory-nudge index |
+| PreToolUse | Guardrails plus Claude-only, non-blocking memory nudges for Grep/Bash/WebSearch. Nudges index catalogue descriptions only, deduplicate per session, cap at five, fail open, and can be disabled with `ASHA_NUDGE=0`. Per-harness enforcement reach → [docs/harness-enforcement.md](../../docs/harness-enforcement.md) |
 | PostToolUse | Intervention (ReasoningBank, vector-index refresh, violation check) — capture moved to `/save` jsonl_reader |
 | UserPromptSubmit | Track user interaction patterns |
 | Stop | Save-preflight cleanup |

--- a/plugins/session/commands/save.md
+++ b/plugins/session/commands/save.md
@@ -59,7 +59,7 @@ Run the synthesis pipeline:
 ```bash
 ASHA_ROOT="${ASHA_ROOT:-$(jq -r '.asha_root // empty' "$HOME/.asha/config.json" 2>/dev/null)}"
 [[ -n "$ASHA_ROOT" ]] || { echo "ERROR: asha_root unresolved — run ./install.sh or launch via the asha wrapper" >&2; exit 1; }
-"$ASHA_ROOT/plugins/session/tools/pattern_analyzer.py" synthesize --days 7 --capture-calibration
+"$ASHA_ROOT/plugins/session/tools/pattern_analyzer.py" synthesize --project-dir "$PROJECT_DIR" --days 7 --capture-calibration
 ```
 
 Then archive and rotate events:
@@ -94,6 +94,16 @@ fi
 ```
 
 Surface any `ERROR` lines in chat (a malformed concept file), but do not block the commit on them.
+
+Then run the fixture-based recall benchmark against the real memory catalogue
+and learnings bundle. This is **warn-only** and always exits zero. Surface the
+aggregate `hit@5` and any rows marked `NEW` in chat; an existing known miss is
+still reported but does not need repeated narration.
+
+```bash
+"$ASHA_ROOT/plugins/session/tools/recall_bench.py" --project-dir "$PROJECT_DIR" --format human
+"$ASHA_ROOT/plugins/session/tools/memory_nudge.py" stats --days 7
+```
 
 Then **suggest cross-links** for recently-touched learnings. This is the model — you — proposing links; it runs only on interactive `/save` (the automatic session-end path has no model and skips it). Best-effort and **non-blocking**: skip silently if the bundle is absent or this was a read-only/throwaway session.
 

--- a/plugins/session/hooks/handlers/post-tool-use.sh
+++ b/plugins/session/hooks/handlers/post-tool-use.sh
@@ -58,6 +58,26 @@ INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // {}' 2>/dev/null || true)
 
+# If a Read follows a memory nudge, mark that nudge acted-on. State and metrics
+# live in the cache rather than dirtying the project's generated events file.
+if [[ "$TOOL_NAME" == "Read" && "${ASHA_NUDGE:-1}" != "0" ]]; then
+    READ_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null || true)
+    NUDGE_SID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+    NUDGE_SID=$(printf '%s' "$NUDGE_SID" | tr -c 'A-Za-z0-9_.-' '_' | cut -c1-120)
+    NUDGE_BASE="${XDG_RUNTIME_DIR:-/tmp}/asha-memory-nudge-$(id -u)"
+    NUDGE_STATE="$NUDGE_BASE/${NUDGE_SID:-unknown}.json"
+    # Avoid a Python process on ordinary Reads. Only a path present in this
+    # session's fired-nudge state can become an acted-on event.
+    if [[ -n "$READ_PATH" && -f "$NUDGE_STATE" ]] \
+       && grep -Fq -- "$READ_PATH" "$NUDGE_STATE" 2>/dev/null; then
+        MEMORY_NUDGE="$PLUGIN_ROOT/tools/memory_nudge.py"
+        PYTHON_CMD=$(get_python_cmd)
+        if [[ -f "$MEMORY_NUDGE" && -n "$PYTHON_CMD" ]]; then
+            printf '%s' "$INPUT" | "$PYTHON_CMD" "$MEMORY_NUDGE" acted >/dev/null 2>&1 || true
+        fi
+    fi
+fi
+
 # Vector DB refresh for indexed file changes (background, non-blocking)
 # Only trigger for files in Memory/, asha/, or .claude/ directories
 case "$TOOL_NAME" in

--- a/plugins/session/hooks/handlers/session-start.sh
+++ b/plugins/session/hooks/handlers/session-start.sh
@@ -60,7 +60,7 @@ if [[ -f "$PATTERN_ANALYZER" && -n "$PYTHON_CMD" ]]; then
         # Recover orphaned session
         echo "<system-reminder>" >&2
         echo "Recovering orphaned session: $ORPHAN_SESSION" >&2
-        "$PYTHON_CMD" "$PATTERN_ANALYZER" recover --session-id "$ORPHAN_SESSION" >/dev/null 2>&1 || true
+        "$PYTHON_CMD" "$PATTERN_ANALYZER" recover --project-dir "$PROJECT_DIR" --session-id "$ORPHAN_SESSION" >/dev/null 2>&1 || true
         echo "Orphaned session recovered and synthesized." >&2
         echo "</system-reminder>" >&2
     fi
@@ -68,6 +68,14 @@ fi
 
 # Store current session ID
 echo "$NEW_SESSION_ID" > "$SESSION_MARKER"
+
+# Build the compact description-only memory nudge index. This is Claude-only
+# runtime behavior, non-blocking, and skipped entirely by the kill switch.
+MEMORY_NUDGE="$PLUGIN_ROOT/tools/memory_nudge.py"
+if [[ "${ASHA_HARNESS:-claude}" == "claude" && "${ASHA_NUDGE:-1}" != "0" \
+      && -f "$MEMORY_NUDGE" && -n "$PYTHON_CMD" ]]; then
+    "$PYTHON_CMD" "$MEMORY_NUDGE" build --project-dir "$PROJECT_DIR" >/dev/null 2>&1 || true
+fi
 
 # ==============================================================================
 # CONTEXT INJECTION

--- a/plugins/session/hooks/hooks.json
+++ b/plugins/session/hooks/hooks.json
@@ -22,6 +22,18 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Grep|Bash|WebSearch",
+        "_asha_harnesses": ["claude"],
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory_nudge.sh",
+            "timeout": 1
+          }
+        ],
+        "description": "Claude-only, non-blocking lexical memory nudge"
+      },
+      {
         "matcher": "Read|Edit|Write|MultiEdit",
         "hooks": [
           {

--- a/plugins/session/hooks/memory_nudge.sh
+++ b/plugins/session/hooks/memory_nudge.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Claude PreToolUse memory nudge. Awareness-only, bounded, and fail-open.
+set -uo pipefail
+
+[[ "${ASHA_NUDGE:-1}" != "0" ]] || exit 0
+SCRIPT_DIR="$(cd -P "$(dirname "$0")" >/dev/null 2>&1 && pwd)" || exit 0
+TOOL="$SCRIPT_DIR/../tools/memory_nudge.py"
+[[ -f "$TOOL" ]] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+INDEX_ARGS=()
+if [[ -n "${ASHA_NUDGE_INDEX:-}" ]]; then
+    [[ -f "$ASHA_NUDGE_INDEX" ]] || exit 0
+    INDEX_ARGS=(--index "$ASHA_NUDGE_INDEX")
+fi
+
+INPUT="$(cat 2>/dev/null || true)"
+[[ -n "$INPUT" ]] || exit 0
+# Python startup plus a tiny cached-index query must not hold up the tool call.
+if command -v timeout >/dev/null 2>&1; then
+    printf '%s' "$INPUT" | timeout 0.1s python3 "$TOOL" "${INDEX_ARGS[@]}" match 2>/dev/null || true
+else
+    printf '%s' "$INPUT" | python3 "$TOOL" "${INDEX_ARGS[@]}" match 2>/dev/null || true
+fi
+exit 0

--- a/plugins/session/skills/memory-maintenance/SKILL.md
+++ b/plugins/session/skills/memory-maintenance/SKILL.md
@@ -120,6 +120,29 @@ Do NOT update for:
 - Temporary context (single-session)
 - Redundant information
 
+## Recall Fixture Convention
+
+When a durable memory records a diagnosed failure or a reusable runbook, add a
+natural-language recall fixture in the same change. Prefer the project's
+`Memory/recall_fixtures.yaml`; use `~/.asha/recall_fixtures.yaml` for memories
+that should be tested across projects.
+
+```yaml
+- q: "root disk full, service healthy, shell output disappeared"
+  expect: reference_pk_lintop_syslog_flood_triage
+```
+
+`expect` is the target memory filename stem or learning id. Keep the question
+phrased as a future user/task symptom, not as a copy of the description. Run:
+
+```bash
+recall_bench.py --project-dir "$PWD" --format human
+```
+
+The metric is hit@5. Misses warn but never block `/session:save`; a new miss
+means a previously passing fixture stopped retrieving and should be corrected
+by repairing the catalogue or description rather than keyword-stuffing bodies.
+
 ## File Interdependencies
 
 **Foundation Files** (always read first):

--- a/plugins/session/templates/recall_fixtures.yaml
+++ b/plugins/session/templates/recall_fixtures.yaml
@@ -1,0 +1,35 @@
+# Recall fixtures are questions a future session may naturally ask, not keyword
+# bags. `expect` is a memory filename stem or a learning id. Add one fixture in
+# the same change whenever a durable diagnosed-failure memory is inscribed.
+# Initial global baseline (2026-07-14): 12/12 hit@5.
+
+# B1 locked recall set (2026-04-17), translated to question -> memory id.
+# The original identity-email question is intentionally excluded: its answer
+# belongs to keeper.md, outside the memory/learning retrieval substrate measured
+# here. A permanently impossible fixture would conceal real score regressions.
+- q: "Where does egregore work happen, and should it be set up in the life repo?"
+  expect: project_egregore_setup
+- q: "Where did the old threshold repository tooling land, and when?"
+  expect: project_threshold_merged
+- q: "Where does asha-marketplace live and how does Claude see it from its plugins directory?"
+  expect: project_marketplace_relocated
+- q: "Where is the pknull.ai working directory, is it independent from life, and what is its remote?"
+  expect: project_journal_site
+- q: "Can task-manager pull Todoist now, or must its MCP connection be verified first?"
+  expect: feedback_verify_agent_output
+- q: "For Gmail Calendar or Drive should I use google-workspace MCP or gws CLI?"
+  expect: feedback_gws_over_mcp
+- q: "What are the UDM SE gateway and Egregore container-host IP addresses?"
+  expect: reference_home_network
+- q: "Which files register a new asha-marketplace plugin?"
+  expect: reference_plugin_registration
+- q: "How does the session and asha persona plugin split connect to ASHA_PERSONA and marketplace installation?"
+  expect: project_asha_prompt_architecture
+
+# Diagnosed failures inscribed after B1 and used by issue #8/#9 acceptance.
+- q: "MC server unjoinable, TPS low, container healthy"
+  expect: reference_modded_mc_server_hang_diagnosis
+- q: "root disk 100% full, Bash output lost"
+  expect: reference_pk_lintop_syslog_flood_triage
+- q: "gws call returns 403 after adding scope"
+  expect: reference_gws_scope_add_token_cache

--- a/plugins/session/tools/jsonl_reader.py
+++ b/plugins/session/tools/jsonl_reader.py
@@ -97,6 +97,32 @@ class IdentityError(RuntimeError):
     """Raised when a save run's harness/session/transcript identity is unsafe."""
 
 
+# WWA provenance is consumed both before synthesis (drift classification) and
+# after synthesis (save_preflight's hard gate). Keep the parser here beside the
+# transcript identity primitives so the two stages cannot drift apart.
+_WWA_HEADER_RE = re.compile(r"^##\s+What Was Accomplished\b.*$", re.MULTILINE)
+_WWA_SESSION_RE = re.compile(r"<!--\s*wwa-session:\s*(\S+?)\s*-->")
+
+
+def lead_wwa_body(text: str) -> Optional[str]:
+    """Return the first WWA section body, or None when no WWA exists."""
+    match = _WWA_HEADER_RE.search(text)
+    if not match:
+        return None
+    start = match.end()
+    next_section = re.search(r"^##\s", text[start:], re.MULTILINE)
+    return text[start:start + next_section.start()] if next_section else text[start:]
+
+
+def lead_wwa_session(text: str) -> Optional[str]:
+    """Return the provenance stamp from the lead WWA section."""
+    body = lead_wwa_body(text)
+    if body is None:
+        return None
+    match = _WWA_SESSION_RE.search(body)
+    return match.group(1) if match else None
+
+
 HARNESS_CHOICES = {"claude", "codex", "copilot", "opencode"}
 _CODEX_ROLLOUT_RE = re.compile(
     r"^rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-"
@@ -185,6 +211,44 @@ def transcript_session_id(path: Path, harness: str) -> Optional[str]:
             return m.group(1)
     if harness == "claude" and path.suffix == ".jsonl":
         return path.stem
+    if harness == "copilot" and path.name == "events.jsonl":
+        return path.parent.name
+    if harness == "opencode" and path.suffix == ".json" and path.stem.startswith("ses_"):
+        return path.stem
+    return None
+
+
+def transcript_session_ids(path: Path, harness: str) -> set[str]:
+    """Collect every explicit native session stamp present in a transcript."""
+    found: set[str] = set()
+    try:
+        for _, data in stream_jsonl(path, label="session identity scan"):
+            sid = None
+            if harness == "claude":
+                sid = data.get("sessionId")
+            elif harness == "codex" and data.get("type") == "session_meta":
+                payload = data.get("payload") or {}
+                sid = payload.get("id") if isinstance(payload, dict) else None
+            elif harness == "copilot":
+                payload = data.get("data") or {}
+                sid = payload.get("sessionId") if isinstance(payload, dict) else None
+            elif harness == "opencode":
+                candidate = data.get("id")
+                sid = candidate if str(candidate).startswith("ses_") else None
+            if sid:
+                found.add(str(sid))
+    except OSError:
+        return set()
+    return found
+
+
+def transcript_path_session_id(path: Path, harness: str) -> Optional[str]:
+    """Extract only the session-id component carried by the native path."""
+    if harness == "claude" and path.suffix == ".jsonl":
+        return path.stem
+    if harness == "codex":
+        match = _CODEX_ROLLOUT_RE.match(path.name)
+        return match.group(1) if match else None
     if harness == "copilot" and path.name == "events.jsonl":
         return path.parent.name
     if harness == "opencode" and path.suffix == ".json" and path.stem.startswith("ses_"):
@@ -289,9 +353,26 @@ def resolve_identity(
 
     embedded_sid = transcript_session_id(transcript_path, resolved_harness)
     if embedded_sid and embedded_sid != resolved_sid:
-        raise IdentityError(
-            f"session id mismatch: resolved {resolved_sid}, transcript contains {embedded_sid}: {transcript_path}"
+        # An authoritative session id outranks a stale/foreign transcript
+        # override. Resolve by exact id using the explicit project directory so
+        # post-synthesis save_preflight sees the same auto-pin as the classifier.
+        correct = (
+            locate_session_log_for_id(resolved_harness, project_dir, resolved_sid)
+            if project_dir is not None
+            else None
         )
+        if correct is None:
+            raise IdentityError(
+                f"session id mismatch: resolved {resolved_sid}, transcript contains "
+                f"{embedded_sid}: {transcript_path}"
+            )
+        transcript_path = correct
+        embedded_sid = transcript_session_id(transcript_path, resolved_harness)
+        if embedded_sid != resolved_sid:
+            raise IdentityError(
+                f"exact-id transcript still mismatched: resolved {resolved_sid}, "
+                f"transcript contains {embedded_sid}: {transcript_path}"
+            )
 
     return SessionIdentity(resolved_harness, resolved_sid, transcript_path)
 
@@ -376,6 +457,42 @@ def _locate_claude(project_dir: Path) -> Optional[Path]:
         return candidates[0]
     if os.environ.get("ASHA_ALLOW_MTIME_FALLBACK") == "1" and candidates:
         return candidates[0]
+    return None
+
+
+def locate_session_log_for_id(
+    harness: str,
+    project_dir: Path,
+    session_id: str,
+) -> Optional[Path]:
+    """Locate an exact session transcript without consulting override env vars.
+
+    Drift recovery calls this after discovering that ASHA_TRANSCRIPT_PATH names
+    a foreign session. Re-entering locate_session_log() would simply return the
+    same override, so exact-id recovery needs a narrow, override-free path.
+    """
+    project_dir = project_dir.resolve()
+    if harness == "claude":
+        base = Path.home() / ".claude" / "projects" / _project_slug_for_claude(project_dir)
+        candidate = base / f"{session_id}.jsonl"
+        return candidate if candidate.exists() else None
+    if harness == "codex":
+        base = Path.home() / ".codex" / "sessions"
+        if not base.exists():
+            return None
+        matches = sorted(
+            base.rglob(f"rollout-*-{session_id}.jsonl"),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+        return matches[0] if matches else None
+    if harness == "copilot":
+        candidate = Path.home() / ".copilot" / "session-state" / session_id / "events.jsonl"
+        return candidate if candidate.exists() else None
+    if harness == "opencode":
+        base = Path.home() / ".local" / "share" / "opencode" / "storage" / "session"
+        matches = list(base.rglob(f"{session_id}.json")) if base.exists() else []
+        return matches[0] if matches else None
     return None
 
 

--- a/plugins/session/tools/memory_nudge.py
+++ b/plugins/session/tools/memory_nudge.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Build and query the compact memory-nudge index. Always fails open at CLI."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import re
+import signal
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from memory_retrieval import (
+    discover_memory_dirs, dump_index, load_index, rank,
+)
+
+
+def _index_path(project: Path | None = None) -> Path:
+    project = (project or Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())).resolve()
+    key = hashlib.sha256(str(project).encode("utf-8")).hexdigest()[:16]
+    return Path.home() / ".cache" / "asha" / f"nudge-index-{key}.json"
+
+
+def build(args) -> None:
+    project = Path(args.project_dir).resolve()
+    # Runtime context injection never crosses project trust boundaries. Global
+    # learnings remain available, but another project's authored memory does not.
+    dirs = discover_memory_dirs(project, all_projects=False)
+    dump_index(Path(args.index) if args.index else _index_path(project), dirs,
+               Path(args.learnings_dir).expanduser())
+
+
+def _match_text(payload: dict) -> tuple[str, str]:
+    tool = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") or {}
+    if tool == "Grep":
+        return tool, str(tool_input.get("pattern") or "")
+    if tool == "Bash":
+        return tool, str(tool_input.get("command") or "")[:200]
+    if tool == "WebSearch":
+        return tool, str(tool_input.get("query") or "")
+    return tool, ""
+
+
+def _safe_session(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", value)[:120] or "unknown"
+
+
+def _log(path: Path, event: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+        if path.is_symlink():
+            return
+        event = {"timestamp": datetime.now(timezone.utc).isoformat(), **event}
+        flags = os.O_WRONLY | os.O_APPEND | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags, 0o600)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.write(json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n")
+            handle.flush()
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass  # Metrics are subordinate to the fail-open nudge path.
+
+
+def _secure_state_dir(path: Path) -> None:
+    path.mkdir(parents=True, mode=0o700, exist_ok=True)
+    info = os.lstat(path)
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+        raise PermissionError(f"unsafe nudge state directory: {path}")
+    os.chmod(path, 0o700)
+
+
+def _default_state_dir() -> str:
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    base = Path(runtime) if runtime else Path("/tmp")
+    return str(base / f"asha-memory-nudge-{os.getuid()}")
+
+
+def _mutate_state(state_file: Path, callback):
+    _secure_state_dir(state_file.parent)
+    lock = state_file.with_suffix(".lock")
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    lock_fd = os.open(lock, flags, 0o600)
+    os.fchmod(lock_fd, 0o600)
+    with os.fdopen(lock_fd, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            if state_file.is_symlink():
+                raise PermissionError(f"unsafe nudge state file: {state_file}")
+            state = json.loads(state_file.read_text(encoding="utf-8")) if state_file.is_file() else {}
+        except (OSError, ValueError, TypeError):
+            state = {}
+        result = callback(state)
+        tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{state_file.name}.", dir=state_file.parent)
+        tmp = Path(tmp_name)
+        try:
+            os.fchmod(tmp_fd, 0o600)
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp_handle:
+                json.dump(state, tmp_handle, separators=(",", ":"))
+                tmp_handle.flush()
+            os.replace(tmp, state_file)
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return result
+
+
+def match(args) -> None:
+    payload = json.load(sys.stdin)
+    tool, query = _match_text(payload)
+    if not query:
+        return
+    entries = load_index(Path(args.index) if args.index else _index_path())
+    ranked = rank(query, entries, limit=2)
+    if not ranked:
+        return
+    best = ranked[0]
+    overlaps = best["overlap"]
+    # High precision: two catalogue-token matches, or one distinctive rare token.
+    rare_limit = max(2, int(best["corpus_size"] * 0.02))
+    distinctive = (len(overlaps) == 1 and len(overlaps[0]) >= 7
+                   and best["min_overlap_df"] <= rare_limit)
+    if best["score"] < args.threshold or (len(overlaps) < 2 and not distinctive):
+        return
+    if len(ranked) > 1 and best["score"] < ranked[1]["score"] * 1.12 and not distinctive:
+        return
+
+    session = _safe_session(str(payload.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID") or "unknown"))
+    state_file = Path(args.state_dir) / f"{session}.json"
+
+    def decide(state: dict):
+        fired = state.setdefault("fired", {})
+        count = int(state.get("count", 0))
+        if best["id"] in fired:
+            return "duplicate"
+        if count >= args.cap:
+            if not state.get("cap_reported"):
+                state["cap_reported"] = True
+                return "capped"
+            return "cap-silent"
+        fired[best["id"]] = {"path": best["path"], "acted": False}
+        state["count"] = count + 1
+        return "fire"
+
+    decision = _mutate_state(state_file, decide)
+    if decision == "capped":
+        print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse",
+              "additionalContext": "memory-nudge: session cap reached; further nudges suppressed"}}))
+        return
+    if decision != "fire":
+        return
+    _log(Path(args.log), {"event": "memory_nudge", "status": "fired", "session_id": session,
+         "tool": tool, "memory_id": best["id"], "path": best["path"], "score": best["score"]})
+    description = best["description"]
+    if len(description) > 180:
+        description = description[:177].rsplit(" ", 1)[0].rstrip() + "..."
+    context = f"memory-nudge: possibly answered by {best['id']} — {description} (Read {best['path']})"
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": context}}))
+
+
+def acted(args) -> None:
+    payload = json.load(sys.stdin)
+    if str(payload.get("tool_name") or "") != "Read":
+        return
+    read_path = str((payload.get("tool_input") or {}).get("file_path") or "")
+    if not read_path:
+        return
+    session = _safe_session(str(payload.get("session_id") or os.environ.get("CLAUDE_CODE_SESSION_ID") or "unknown"))
+    state_file = Path(args.state_dir) / f"{session}.json"
+    acted_ids: list[str] = []
+
+    def mark(state: dict):
+        for memory_id, item in state.get("fired", {}).items():
+            if not item.get("acted") and os.path.realpath(str(item.get("path", ""))) == os.path.realpath(read_path):
+                item["acted"] = True
+                acted_ids.append(memory_id)
+
+    _mutate_state(state_file, mark)
+    for memory_id in acted_ids:
+        _log(Path(args.log), {"event": "memory_nudge", "status": "acted", "session_id": session,
+             "memory_id": memory_id, "path": read_path})
+
+
+def stats(args) -> None:
+    path = Path(args.log)
+    fired: set[tuple[str, str]] = set()
+    acted_on: set[tuple[str, str]] = set()
+    cutoff = datetime.now(timezone.utc).timestamp() - args.days * 86400
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        lines = []
+    for line in lines:
+        try:
+            event = json.loads(line)
+            timestamp = datetime.fromisoformat(str(event["timestamp"]).replace("Z", "+00:00")).timestamp()
+            if timestamp < cutoff:
+                continue
+            key = (str(event.get("session_id") or ""), str(event.get("memory_id") or ""))
+            if event.get("status") == "fired":
+                fired.add(key)
+            elif event.get("status") == "acted":
+                acted_on.add(key)
+        except (ValueError, TypeError, KeyError, json.JSONDecodeError):
+            continue
+    acted_count = len(fired & acted_on)
+    result = {"days": args.days, "fired": len(fired), "acted": acted_count,
+              "acted_rate": round(acted_count / len(fired), 4) if fired else 0.0}
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(f"memory nudges ({args.days}d): {len(fired)} fired, {acted_count} acted-on "
+              f"({result['acted_rate'] * 100:.1f}%)")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    root.add_argument("--index")
+    root.add_argument("--learnings-dir", default=str(Path.home() / ".asha" / "learnings"))
+    root.add_argument("--state-dir", default=_default_state_dir())
+    root.add_argument("--log", default=str(Path.home() / ".cache" / "asha" / "nudge-events.jsonl"))
+    sub = root.add_subparsers(dest="command", required=True)
+    build_parser = sub.add_parser("build")
+    build_parser.add_argument("--project-dir", default=os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    match_parser = sub.add_parser("match")
+    match_parser.add_argument("--threshold", type=float, default=0.28)
+    match_parser.add_argument("--cap", type=int, default=5)
+    sub.add_parser("acted")
+    stats_parser = sub.add_parser("stats")
+    stats_parser.add_argument("--days", type=int, default=7)
+    stats_parser.add_argument("--json", action="store_true")
+    return root
+
+
+def _timeout(_signum, _frame) -> None:
+    raise TimeoutError
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        if args.command == "match" and hasattr(signal, "setitimer"):
+            signal.signal(signal.SIGALRM, _timeout)
+            signal.setitimer(signal.ITIMER_REAL, 0.095)
+        try:
+            {"build": build, "match": match, "acted": acted, "stats": stats}[args.command](args)
+        finally:
+            if args.command == "match" and hasattr(signal, "setitimer"):
+                signal.setitimer(signal.ITIMER_REAL, 0)
+    except Exception:
+        pass  # The hook contract is fail-open and silent on every internal error.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/session/tools/memory_retrieval.py
+++ b/plugins/session/tools/memory_retrieval.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Shared lexical retrieval substrate for recall benchmarks and memory nudges.
+
+Only compact catalogue text is indexed: MEMORY.md entries, memory frontmatter
+descriptions, and learning frontmatter titles/descriptions. Memory bodies are
+never read into the index.
+"""
+
+from __future__ import annotations
+
+import json
+import fcntl
+import math
+import os
+import re
+import tempfile
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+_WORD_RE = re.compile(r"[a-z0-9][a-z0-9_+.-]*", re.IGNORECASE)
+_MEMORY_LINE_RE = re.compile(
+    r"^\s*-\s*\[([^]]+)\]\(([^)]+\.md)\)\s*(?:[-–—:]\s*)?(.*)$"
+)
+_FRONTMATTER_RE = re.compile(r"^\ufeff?---\s*\r?\n(.*?)\r?\n---\s*(?:\r?\n|$)", re.DOTALL)
+_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "been", "but", "by", "can",
+    "do", "does", "for", "from", "had", "has", "have", "how", "i", "if",
+    "in", "into", "is", "it", "its", "me", "my", "not", "of", "on", "or",
+    "our", "should", "that", "the", "their", "then", "this", "to", "use",
+    "was", "we", "what", "when", "where", "which", "with", "you", "your",
+}
+
+
+@dataclass(frozen=True)
+class Entry:
+    id: str
+    description: str
+    path: str
+    source: str
+    tokens: tuple[str, ...]
+
+    def json(self) -> dict:
+        value = asdict(self)
+        value["tokens"] = list(self.tokens)
+        return value
+
+
+def tokenize(text: str) -> list[str]:
+    """Stable tokenization shared by the benchmark and hook matcher."""
+    values: list[str] = []
+    for raw in _WORD_RE.findall(text.lower()):
+        token = raw.strip("._+-")
+        if len(token) < 2 or token in _STOPWORDS:
+            continue
+        # Keep both a dashed identifier and its components searchable.
+        values.append(token)
+        if "-" in token or "_" in token:
+            values.extend(p for p in re.split(r"[-_]", token) if len(p) >= 2)
+    return values
+
+
+def _frontmatter(text: str) -> dict[str, object]:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    # The fields used here are scalar strings. This small parser deliberately
+    # avoids making PyYAML a runtime dependency for a latency-sensitive hook.
+    data: dict[str, object] = {}
+    current: Optional[str] = None
+    for line in match.group(1).splitlines():
+        if line[:1].isspace() and current and isinstance(data.get(current), str):
+            data[current] = f"{data[current]} {line.strip()}".strip()
+            continue
+        if ":" not in line or line.lstrip().startswith("#"):
+            current = None
+            continue
+        key, value = line.split(":", 1)
+        current = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        data[current] = value
+    return data
+
+
+def _entry(entry_id: str, description: str, path: Path, source: str) -> Entry:
+    clean = " ".join(description.split())
+    return Entry(entry_id, clean, str(path), source, tuple(tokenize(clean)))
+
+
+def memory_entries(memory_dirs: Iterable[Path]) -> list[Entry]:
+    """Read MEMORY.md catalogue lines and target-file descriptions."""
+    found: dict[tuple[str, str], Entry] = {}
+    for memory_dir in memory_dirs:
+        index = memory_dir / "MEMORY.md"
+        indexed: dict[str, tuple[str, Path]] = {}
+        if index.is_file():
+            try:
+                for line in index.read_text(encoding="utf-8").splitlines():
+                    match = _MEMORY_LINE_RE.match(line)
+                    if not match:
+                        continue
+                    target = (memory_dir / match.group(2)).resolve()
+                    indexed[target.stem] = (
+                        " ".join(part for part in (match.group(1), match.group(3)) if part),
+                        target,
+                    )
+            except OSError:
+                pass
+
+        targets = {path for _, path in indexed.values()}
+        try:
+            targets.update(p.resolve() for p in memory_dir.glob("*.md") if p.name != "MEMORY.md")
+        except OSError:
+            pass
+        for path in sorted(targets):
+            catalogue, _ = indexed.get(path.stem, (path.stem, path))
+            description = ""
+            try:
+                description = str(_frontmatter(path.read_text(encoding="utf-8")).get("description") or "")
+            except OSError:
+                pass
+            text = " ".join(part for part in (catalogue, description) if part)
+            if text:
+                found[(path.stem, str(path))] = _entry(path.stem, text, path, "memory")
+    return list(found.values())
+
+
+def learning_entries(learnings_dir: Path) -> list[Entry]:
+    """Read the same OKF scalar fields that learnings_manager indexes/renders."""
+    if not learnings_dir.is_dir():
+        return []
+    entries: list[Entry] = []
+    for path in sorted(learnings_dir.glob("*.md")):
+        if path.name in {"index.md", "log.md"}:
+            continue
+        try:
+            data = _frontmatter(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        entry_id = str(data.get("id") or path.stem)
+        # trigger is the historical learnings_manager query field. New OKF
+        # files mirror it into description; keeping it here preserves old files.
+        description = " ".join(str(data.get(k) or "") for k in ("title", "description", "trigger"))
+        entries.append(_entry(entry_id, description, path, "learning"))
+    return entries
+
+
+def claude_memory_dir(project_dir: Path, home: Optional[Path] = None) -> Path:
+    home = home or Path.home()
+    key = str(project_dir.resolve()).replace(os.sep, "-")
+    return home / ".claude" / "projects" / key / "memory"
+
+
+def discover_memory_dirs(project_dir: Optional[Path], *, all_projects: bool = False,
+                         home: Optional[Path] = None) -> list[Path]:
+    home = home or Path.home()
+    result: list[Path] = []
+    override = os.environ.get("ASHA_MEMORY_DIR")
+    if override:
+        result.append(Path(override).expanduser())
+    if project_dir:
+        native = project_dir / "Memory"
+        if (native / "MEMORY.md").is_file():
+            result.append(native)
+        result.append(claude_memory_dir(project_dir, home))
+    if all_projects:
+        # Deliberately scoped to Claude's project-memory catalogue. Never scan HOME.
+        result.extend((home / ".claude" / "projects").glob("*/memory"))
+    unique: dict[str, Path] = {}
+    for path in result:
+        if path.is_dir():
+            unique[str(path.resolve())] = path.resolve()
+    return sorted(unique.values())
+
+
+def build_entries(memory_dirs: Iterable[Path], learnings_dir: Optional[Path] = None) -> list[Entry]:
+    entries = memory_entries(memory_dirs)
+    entries.extend(learning_entries(learnings_dir or (Path.home() / ".asha" / "learnings")))
+    return entries
+
+
+def source_signature(memory_dirs: Iterable[Path], learnings_dir: Path) -> dict[str, int]:
+    """Compact mtime/size signature used to skip unchanged SessionStart builds."""
+    paths: list[Path] = []
+    for directory in memory_dirs:
+        try:
+            paths.extend(directory.glob("*.md"))
+        except OSError:
+            pass
+    if learnings_dir.is_dir():
+        paths.extend(learnings_dir.glob("*.md"))
+    signature: dict[str, int] = {}
+    for path in paths:
+        try:
+            stat = path.stat()
+            signature[str(path)] = stat.st_mtime_ns ^ stat.st_size
+        except OSError:
+            pass
+    return signature
+
+
+def rank(query: str, entries: Iterable[Entry], limit: int = 5) -> list[dict]:
+    entries = list(entries)
+    query_tokens = tokenize(query)
+    if not query_tokens or not entries:
+        return []
+    query_set = set(query_tokens)
+    df: dict[str, int] = {}
+    for item in entries:
+        for token in set(item.tokens):
+            df[token] = df.get(token, 0) + 1
+    total = len(entries)
+
+    def idf(token: str) -> float:
+        return math.log((total + 1) / (df.get(token, 0) + 1)) + 1.0
+
+    denominator = sum(idf(token) for token in query_set) or 1.0
+    results: list[dict] = []
+    normalized_query = " ".join(query_tokens)
+    for item in entries:
+        item_set = set(item.tokens)
+        overlap = query_set & item_set
+        if not overlap:
+            continue
+        overlap_weight = sum(idf(token) for token in overlap)
+        score = overlap_weight / denominator
+        normalized_desc = " ".join(item.tokens)
+        if len(normalized_query) >= 5 and normalized_query in normalized_desc:
+            score += 0.25
+        results.append({
+            "id": item.id,
+            "description": item.description,
+            "path": item.path,
+            "source": item.source,
+            "score": round(score, 6),
+            "overlap": sorted(overlap),
+            "overlap_idf": round(overlap_weight, 6),
+            "max_overlap_idf": round(max(idf(token) for token in overlap), 6),
+            "min_overlap_df": min(df.get(token, 0) for token in overlap),
+            "corpus_size": total,
+        })
+    results.sort(key=lambda row: (-row["score"], -len(row["overlap"]), row["id"], row["path"]))
+    return results[:limit]
+
+
+def dump_index(path: Path, memory_dirs: list[Path], learnings_dir: Path) -> dict:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    lock_fd = os.open(lock_path, flags, 0o600)
+    os.fchmod(lock_fd, 0o600)
+    with os.fdopen(lock_fd, "a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        signature = source_signature(memory_dirs, learnings_dir)
+        if path.is_file() and not path.is_symlink():
+            try:
+                old = json.loads(path.read_text(encoding="utf-8"))
+                if old.get("source_signature") == signature:
+                    os.chmod(path, 0o600)
+                    return old
+            except (OSError, ValueError, TypeError):
+                pass
+        payload = {
+            "version": 1,
+            "source_signature": signature,
+            "entries": [entry.json() for entry in build_entries(memory_dirs, learnings_dir)],
+        }
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        tmp = Path(tmp_name)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        return payload
+
+
+def load_index(path: Path) -> list[Entry]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [Entry(
+        id=str(item["id"]), description=str(item["description"]),
+        path=str(item["path"]), source=str(item["source"]),
+        tokens=tuple(str(v) for v in item.get("tokens", [])),
+    ) for item in data.get("entries", [])]

--- a/plugins/session/tools/pattern_analyzer.py
+++ b/plugins/session/tools/pattern_analyzer.py
@@ -6,7 +6,7 @@ Reads events.jsonl, identifies recurring patterns, extracts calibration signals,
 and synthesizes Memory files using the Four Questions structure.
 
 Usage:
-    python pattern_analyzer.py synthesize [--session-id ID]
+    python pattern_analyzer.py synthesize --project-dir DIR [--session-id ID]
     python pattern_analyzer.py patterns [--min-confidence 0.7]
     python pattern_analyzer.py calibration [--session-id ID]
 """
@@ -15,9 +15,14 @@ import os
 import re
 import sys
 import json
+import fcntl
 import hashlib
 import argparse
 import subprocess
+import tempfile
+import stat
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, List, Tuple
@@ -25,7 +30,18 @@ from collections import defaultdict, Counter
 
 
 def detect_project_root() -> Path:
-    """Find project root via environment, git, or upward search for Memory/"""
+    """Find project root, honoring the CLI's explicit directory before cwd."""
+    for index, argument in enumerate(sys.argv[1:]):
+        explicit = None
+        if argument in {"--project-dir", "-p"} and index + 2 <= len(sys.argv[1:]):
+            explicit = sys.argv[1:][index + 1]
+        elif argument.startswith("--project-dir="):
+            explicit = argument.split("=", 1)[1]
+        if explicit:
+            project_path = Path(explicit).resolve()
+            if (project_path / "Memory").is_dir():
+                return project_path
+
     claude_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
     if claude_project_dir:
         project_path = Path(claude_project_dir)
@@ -66,6 +82,78 @@ VOICE_FILE = Path.home() / ".asha" / "voice.md"
 KEEPER_FILE = Path.home() / ".asha" / "keeper.md"
 PATTERNS_FILE = PROJECT_ROOT / "Memory" / "events" / "patterns.json"
 SILENCE_MARKER = PROJECT_ROOT / "Work" / "markers" / "silence"
+
+
+def configure_project_root(project_dir: Path) -> None:
+    """Bind all synthesis paths to the caller's explicit project directory."""
+    global PROJECT_ROOT, EVENTS_FILE, ACTIVE_CONTEXT, PATTERNS_FILE
+    global SILENCE_MARKER, EVAL_RESULTS_FILE
+    PROJECT_ROOT = project_dir.resolve()
+    events_override = os.environ.get("ASHA_EVENTS_FILE")
+    EVENTS_FILE = (
+        Path(events_override)
+        if events_override
+        else PROJECT_ROOT / "Memory" / "events" / "events.jsonl"
+    )
+    ACTIVE_CONTEXT = PROJECT_ROOT / "Memory" / "activeContext.md"
+    PATTERNS_FILE = PROJECT_ROOT / "Memory" / "events" / "patterns.json"
+    SILENCE_MARKER = PROJECT_ROOT / "Work" / "markers" / "silence"
+    EVAL_RESULTS_FILE = PROJECT_ROOT / "Memory" / "events" / "eval_history.jsonl"
+
+
+@contextmanager
+def _project_save_lock(project_dir: Path):
+    """Serialize the full save transaction for one project."""
+    roots = [Path(os.environ["XDG_RUNTIME_DIR"])] if os.environ.get("XDG_RUNTIME_DIR") else []
+    roots.append(Path("/tmp"))
+    lock_dir = None
+    last_error = None
+    for runtime in roots:
+        candidate = runtime / f"asha-save-locks-{os.getuid()}"
+        try:
+            candidate.mkdir(parents=True, mode=0o700, exist_ok=True)
+            info = os.lstat(candidate)
+            if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid():
+                raise PermissionError(f"unsafe save lock directory: {candidate}")
+            os.chmod(candidate, 0o700)
+            lock_dir = candidate
+            break
+        except OSError as exc:
+            last_error = exc
+    if lock_dir is None:
+        raise PermissionError("no safe writable save lock directory") from last_error
+    key = hashlib.sha256(str(project_dir.resolve()).encode("utf-8")).hexdigest()[:24]
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(lock_dir / f"{key}.lock", flags, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Replace a text file atomically without exposing a truncated state."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    mode = (path.stat().st_mode & 0o777) if path.exists() else 0o644
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 # Calibration signal patterns
@@ -423,52 +511,215 @@ def _strict_save_mode() -> bool:
     return os.environ.get("ASHA_SAVE_STRICT") == "1"
 
 
-def _current_identity(project_dir: Path, session_id: Optional[str] = None):
+@dataclass
+class DriftDecision:
+    classification: str
+    identity: object
+    transcript_events: list
+    synth_events: List[Dict]
+    tool_summary: str = ""
+    topic: str = "session activity"
+    needs_minimal_wwa: bool = False
+    concurrent_session: Optional[str] = None
+    detail: str = ""
+
+
+def _event_timestamp_is_recent(value: str, minutes: int = 15) -> bool:
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError):
+        return False
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - timestamp.astimezone(timezone.utc)
+    return timedelta(0) <= age <= timedelta(minutes=minutes)
+
+
+def _recent_session_activity(events_file: Path, session_id: str) -> bool:
+    if not events_file.exists():
+        return False
+    for line in events_file.read_text(errors="replace").splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            event.get("session_id") == session_id
+            and _event_timestamp_is_recent(event.get("timestamp", ""))
+        ):
+            return True
+    return False
+
+
+def _topic_from_events(events: List[Dict]) -> str:
+    for event in events:
+        if event.get("subtype") == "decision":
+            detail = str((event.get("payload") or {}).get("detail", "")).strip()
+            if detail:
+                return re.sub(r"\s+", " ", detail)[:72].rstrip(" .")
+    return "session tool activity"
+
+
+def _tool_activity_summary(transcript_events: list) -> str:
+    tools = Counter(
+        str(event.tool)
+        for event in transcript_events
+        if event.kind in {"tool_use", "skill", "agent"} and event.tool
+    )
+    return ", ".join(
+        f"{tool} ({count}x)" if count > 1 else tool
+        for tool, count in tools.most_common(8)
+    )
+
+
+def _declared_identity_parts(jsonl_reader, session_id: Optional[str]):
+    candidate_text = os.environ.get("ASHA_TRANSCRIPT_PATH")
+    candidate = Path(os.path.expanduser(candidate_text)) if candidate_text else None
+    harness = os.environ.get("ASHA_HARNESS")
+    if not harness and candidate and candidate.exists():
+        harness = jsonl_reader.sniff_harness(candidate)
+    if not harness:
+        harness = jsonl_reader.detect_harness_from_env()
+    if not harness:
+        raise RuntimeError("save harness is unknown")
+    sid = session_id or os.environ.get("ASHA_SESSION_ID") or jsonl_reader._native_session_id(harness)
+    if not sid:
+        raise RuntimeError("current session id is unknown")
+    return harness, sid, candidate
+
+
+def classify_drift(project_dir: Path, session_id: Optional[str] = None) -> DriftDecision:
+    """Classify transcript/event drift before synthesis writes shared state."""
     try:
         import jsonl_reader  # type: ignore
     except ImportError as exc:
-        if _strict_save_mode() or session_id:
-            raise RuntimeError(f"jsonl_reader unavailable: {exc}") from exc
-        return None
+        raise RuntimeError(f"UNCLASSIFIABLE: jsonl_reader unavailable: {exc}") from exc
+
     try:
-        return jsonl_reader.resolve_identity(project_dir, session_id=session_id)
-    except Exception as exc:  # noqa: BLE001 - convert identity failure to save result
-        has_identity_signal = any(os.environ.get(k) for k in (
-            "ASHA_HARNESS", "ASHA_SESSION_ID", "ASHA_TRANSCRIPT_PATH",
-            "CLAUDE_CODE_SESSION_ID", "CODEX_THREAD_ID", "COPILOT_SESSION_ID",
-        ))
-        if _strict_save_mode() or session_id or has_identity_signal:
-            raise RuntimeError(str(exc)) from exc
-        return None
+        harness, current_sid, candidate = _declared_identity_parts(jsonl_reader, session_id)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"UNCLASSIFIABLE: {exc}") from exc
+
+    candidate = candidate or jsonl_reader.locate_session_log(harness, project_dir)
+    if candidate is None or not candidate.exists():
+        raise RuntimeError(
+            f"UNCLASSIFIABLE: no candidate transcript for {harness} session {current_sid}"
+        )
+
+    candidate_sid = jsonl_reader.transcript_session_id(candidate, harness)
+    candidate_path_sid = jsonl_reader.transcript_path_session_id(candidate, harness)
+    classification = "CLEAN"
+    detail = f"transcript {candidate} matches session {current_sid}"
+    selected = candidate
+    if candidate_sid != current_sid or candidate_path_sid != current_sid:
+        correct = jsonl_reader.locate_session_log_for_id(harness, project_dir, current_sid)
+        if correct is None:
+            raise RuntimeError(
+                "UNCLASSIFIABLE: candidate transcript belongs to "
+                f"{candidate_sid or 'unknown'} at path id {candidate_path_sid or 'unknown'}, "
+                f"expected {current_sid}, and no exact transcript exists"
+            )
+        selected = correct
+        classification = "WRONG_TRANSCRIPT"
+        detail = f"candidate {candidate} belonged to {candidate_sid}; auto-pinned {correct}"
+
+    selected_sids = jsonl_reader.transcript_session_ids(selected, harness)
+    selected_path_sid = jsonl_reader.transcript_path_session_id(selected, harness)
+    if selected_sids != {current_sid} or selected_path_sid != current_sid:
+        raise RuntimeError(
+            "UNCLASSIFIABLE: selected transcript identity is not wholly current: "
+            f"event stamps={sorted(selected_sids)}, path id={selected_path_sid or 'unknown'}, "
+            f"expected only {current_sid}"
+        )
+
+    try:
+        identity = jsonl_reader.resolve_identity(
+            project_dir,
+            harness=harness,
+            session_id=current_sid,
+            transcript=selected,
+        )
+        transcript_events = list(jsonl_reader.stream_events(selected, harness))
+        synth_events = jsonl_reader.to_synth_events(transcript_events, project_dir, identity.session_id)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"UNCLASSIFIABLE: transcript parse failed: {exc}") from exc
+
+    tool_summary = _tool_activity_summary(transcript_events)
+    has_edits = any(
+        event.get("subtype") in {"file_modified", "file_created"}
+        for event in synth_events
+    )
+    needs_minimal = bool(tool_summary and not has_edits)
+    if needs_minimal and not synth_events:
+        synth_events.append({
+            "id": f"evt_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}_toolactivity",
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "session_id": identity.session_id,
+            "type": "event",
+            "subtype": "tool_activity",
+            "payload": {"detail": f"Tool activity: {tool_summary}"},
+            "metadata": {"source": "drift_classifier", "project_dir": str(project_dir)},
+        })
+    if classification == "CLEAN" and needs_minimal:
+        classification = "NO_EDIT_EVENTS"
+        detail = "correct transcript has tool activity but no Edit/Write events"
+
+    concurrent_sid = None
+    active_context = project_dir / "Memory" / "activeContext.md"
+    if active_context.exists():
+        foreign_sid = jsonl_reader.lead_wwa_session(active_context.read_text(errors="replace"))
+        canonical_events = project_dir / "Memory" / "events" / "events.jsonl"
+        if (
+            foreign_sid
+            and foreign_sid != current_sid
+            and _recent_session_activity(canonical_events, foreign_sid)
+        ):
+            concurrent_sid = foreign_sid
+            if classification == "CLEAN":
+                classification = "CONCURRENT"
+                detail = f"lead WWA belongs to active session {foreign_sid}"
+
+    return DriftDecision(
+        classification=classification,
+        identity=identity,
+        transcript_events=transcript_events,
+        synth_events=synth_events,
+        tool_summary=tool_summary,
+        topic=_topic_from_events(synth_events),
+        needs_minimal_wwa=needs_minimal,
+        concurrent_session=concurrent_sid,
+        detail=detail,
+    )
 
 
-def _rebuild_events_from_transcript(project_dir: Path, session_id: Optional[str] = None):
+def _rebuild_events_from_transcript(
+    project_dir: Path,
+    session_id: Optional[str] = None,
+    decision: Optional[DriftDecision] = None,
+):
     """Regenerate EVENTS_FILE from the active harness transcript.
 
     Returns (event_count, session_id). If ASHA_EVENTS_FILE is set, the caller is
     responsible for that file; identity is still resolved so synthesis can filter
     by the current session instead of laundering stale event contents.
     """
-    identity = _current_identity(project_dir, session_id=session_id)
-    if identity is None:
-        return 0, session_id
+    global _LAST_DRIFT_DECISION
+    decision = decision or classify_drift(project_dir, session_id=session_id)
+    _LAST_DRIFT_DECISION = decision
+    identity = decision.identity
     if os.environ.get("ASHA_EVENTS_FILE"):
         return 0, identity.session_id
 
-    import jsonl_reader  # type: ignore
-    try:
-        events = list(jsonl_reader.stream_events(identity.transcript_path, identity.harness))
-        synth = jsonl_reader.to_synth_events(events, project_dir, identity.session_id)
-    except Exception as exc:  # noqa: BLE001
-        raise RuntimeError(f"transcript rebuild failed: {exc}") from exc
+    synth = decision.synth_events
 
-    EVENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    # Truncate even when the parse yields zero synth events. Leaving the stale
-    # file intact is the bleed vector this guard exists to close.
-    with open(EVENTS_FILE, "w") as f:
-        for ev in synth:
-            f.write(json.dumps(ev) + "\n")
+    # Replace even when the parse yields zero synth events. Leaving the stale
+    # file intact is a bleed vector, whilst direct truncation exposes a partial
+    # state to readers if the process dies mid-write.
+    _atomic_write_text(EVENTS_FILE, "".join(json.dumps(ev) + "\n" for ev in synth))
     return len(synth), identity.session_id
+
+
+_LAST_DRIFT_DECISION: Optional[DriftDecision] = None
 
 def get_last_session_id() -> Optional[str]:
     """Get the most recent session ID from events"""
@@ -874,6 +1125,33 @@ def generate_active_context(events: List[Dict], existing_patterns: Dict,
     return "\n".join(lines)
 
 
+def _prepend_recovery_wwa(
+    content: str,
+    session_id: str,
+    topic: str,
+    tool_summary: str,
+) -> str:
+    """Prepend a stamped WWA without disturbing a concurrent session's WWA."""
+    try:
+        import jsonl_reader  # type: ignore
+        if jsonl_reader.lead_wwa_session(content) == session_id:
+            return content
+    except ImportError:
+        pass
+
+    heading = f"## What Was Accomplished ({datetime.now(timezone.utc).date()} — {topic})"
+    summary = tool_summary or "tool activity recorded in the session transcript"
+    section = (
+        f"{heading}\n\n"
+        f"<!-- {WWA_SESSION_MARKER}: {session_id} -->\n"
+        f"- Tool activity: {summary}.\n\n"
+    )
+    match = re.search(r"^##\s", content, re.MULTILINE)
+    if not match:
+        return content.rstrip() + "\n\n" + section
+    return content[:match.start()].rstrip() + "\n\n" + section + content[match.start():]
+
+
 # =============================================================================
 # Calibration Updates
 # =============================================================================
@@ -1171,8 +1449,24 @@ def run_synthesis(
     days: int = 7,
     skip_eval: bool = False,
     capture_calibration: bool = False,
+    project_dir: Optional[Path] = None,
+    _lock_held: bool = False,
 ) -> Dict:
     """Run full synthesis pipeline"""
+    if project_dir is not None:
+        configure_project_root(project_dir)
+    if not _lock_held:
+        # Classification, event replacement, curated merge, and publication
+        # form one transaction. Re-entry avoids indenting every early return.
+        with _project_save_lock(PROJECT_ROOT):
+            return run_synthesis(
+                session_id=session_id,
+                days=days,
+                skip_eval=skip_eval,
+                capture_calibration=capture_calibration,
+                project_dir=PROJECT_ROOT,
+                _lock_held=True,
+            )
     # Silence marker honored across the whole synthesis. Same semantics as
     # the hook handlers: if the user has /silence on, an explicit /save must
     # not write to Memory/, ~/.asha/learnings.md, voice.md, or keeper.md.
@@ -1191,12 +1485,15 @@ def run_synthesis(
         "events_processed": 0,
         "patterns_found": 0,
         "calibration_signals": {"voice": 0, "keeper": 0},
-        "eval": None
+        "eval": None,
+        "drift": None,
     }
 
     # Refresh events from the active harness transcript before loading. Identity
     # failure on a save path is fatal to synthesis; falling back to stale shared
     # events is how foreign-session handoffs are produced.
+    global _LAST_DRIFT_DECISION
+    _LAST_DRIFT_DECISION = None
     try:
         rebuilt, resolved_sid = _rebuild_events_from_transcript(PROJECT_ROOT, session_id=session_id)
     except RuntimeError as exc:
@@ -1208,6 +1505,26 @@ def run_synthesis(
         results["session_id"] = session_id
     if rebuilt:
         results["events_rebuilt_from_transcript"] = rebuilt
+
+    decision = _LAST_DRIFT_DECISION
+    if decision is not None:
+        actions = []
+        if decision.classification == "WRONG_TRANSCRIPT":
+            actions.append("auto-pinned")
+        if decision.needs_minimal_wwa:
+            actions.append("minimal-WWA")
+        if decision.concurrent_session:
+            actions.append("prepended-preserving-concurrent")
+            results["concurrency"] = (
+                f"> Concurrency: preserved WWA from active session {decision.concurrent_session}"
+            )
+        suffix = f"→{'+'.join(actions)}" if actions else ""
+        results["drift"] = f"{decision.classification}{suffix}"
+        results["drift_detail"] = decision.detail
+        if decision.needs_minimal_wwa:
+            results["drift_action_required"] = (
+                "Auto-generated minimal stamped WWA; flesh it out before commit when an agent is present."
+            )
 
     # Load events. When identity is known, filter to it; never infer a current
     # save session from event contents.
@@ -1251,7 +1568,19 @@ def run_synthesis(
             results["activeContext_merged"] = True
         active_context = merged
 
-    ACTIVE_CONTEXT.write_text(active_context)
+    if decision is not None and (
+        decision.needs_minimal_wwa
+        or decision.concurrent_session
+        or decision.classification == "WRONG_TRANSCRIPT"
+    ):
+        active_context = _prepend_recovery_wwa(
+            active_context,
+            session_id or decision.identity.session_id,
+            decision.topic,
+            decision.tool_summary,
+        )
+
+    _atomic_write_text(ACTIVE_CONTEXT, active_context)
     _write_synthhash(active_context)
 
     # Extract learnings for activeContext display
@@ -1583,6 +1912,12 @@ def main():
     # Synthesize command
     synth_parser = subparsers.add_parser("synthesize", help="Run full synthesis pipeline")
     synth_parser.add_argument("--session-id", "-s", help="Specific session to synthesize")
+    synth_parser.add_argument(
+        "--project-dir",
+        "-p",
+        required=True,
+        help="Explicit project root used for transcript resolution",
+    )
     synth_parser.add_argument("--days", "-d", type=int, default=7, help="Days of history (default: 7)")
     synth_parser.add_argument(
         "--capture-calibration",
@@ -1606,6 +1941,7 @@ def main():
     # Recover command
     recover_parser = subparsers.add_parser("recover", help="Recover and synthesize orphaned session")
     recover_parser.add_argument("--session-id", "-s", required=True, help="Orphaned session ID")
+    recover_parser.add_argument("--project-dir", "-p", required=True, help="Explicit project root")
 
     # Eval command
     eval_parser = subparsers.add_parser("eval", help="Evaluate a session")
@@ -1631,6 +1967,7 @@ def main():
                 session_id=args.session_id,
                 days=args.days,
                 capture_calibration=args.capture_calibration,
+                project_dir=Path(args.project_dir),
             )
             print(json.dumps(result, indent=2))
 
@@ -1656,7 +1993,11 @@ def main():
                 print(json.dumps({"orphaned_session": None}))
 
         elif args.command == "recover":
-            result = run_synthesis(session_id=args.session_id, days=30)
+            result = run_synthesis(
+                session_id=args.session_id,
+                days=30,
+                project_dir=Path(args.project_dir),
+            )
             result["recovered"] = True
             print(json.dumps(result, indent=2))
 

--- a/plugins/session/tools/recall_bench.py
+++ b/plugins/session/tools/recall_bench.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Warn-only question-to-memory recall benchmark (hit@k)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from memory_retrieval import build_entries, discover_memory_dirs, rank
+
+
+def _scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def load_fixtures(path: Path) -> list[dict[str, str]]:
+    """Load the deliberately tiny q/expect YAML schema without dependencies."""
+    text = path.read_text(encoding="utf-8")
+    if text.lstrip().startswith("["):
+        raw = json.loads(text)
+        return [{"q": str(row["q"]), "expect": str(row["expect"])} for row in raw]
+    rows: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.split(" #", 1)[0].rstrip()
+        match = re.match(r"^\s*-\s*q\s*:\s*(.+)$", line)
+        if match:
+            if current:
+                rows.append(current)
+            current = {"q": _scalar(match.group(1))}
+            continue
+        match = re.match(r"^\s+expect\s*:\s*(.+)$", line)
+        if match and current:
+            current["expect"] = _scalar(match.group(1))
+    if current:
+        rows.append(current)
+    bad = [i + 1 for i, row in enumerate(rows) if not row.get("q") or not row.get("expect")]
+    if bad:
+        raise ValueError(f"fixtures missing q/expect at entries: {bad}")
+    return rows
+
+
+def find_fixtures(project_dir: Path, explicit: str | None) -> tuple[Path, bool]:
+    if explicit:
+        return Path(explicit).expanduser(), False
+    local = project_dir / "Memory" / "recall_fixtures.yaml"
+    if local.is_file():
+        return local, False
+    return Path.home() / ".asha" / "recall_fixtures.yaml", True
+
+
+def _load_prior(path: Path) -> dict[str, bool]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {str(k): bool(v) for k, v in data.get("hits", {}).items()}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def run_benchmark(fixtures: list[dict[str, str]], entries, *, k: int,
+                  prior: dict[str, bool]) -> dict:
+    cases = []
+    hits: dict[str, bool] = {}
+    for fixture in fixtures:
+        ranked = rank(fixture["q"], entries, limit=k)
+        expected = fixture["expect"]
+        hit = any(row["id"] == expected for row in ranked)
+        key = f"{fixture['q']}\x00{expected}"
+        new_miss = not hit and prior.get(key, True)
+        hits[key] = hit
+        cases.append({
+            "q": fixture["q"], "expect": expected, "hit": hit,
+            "new_miss": new_miss,
+            "top": [{"id": row["id"], "score": row["score"]} for row in ranked],
+        })
+    count = sum(1 for case in cases if case["hit"])
+    return {
+        "status": "ok", "metric": f"hit@{k}", "hits": count,
+        "total": len(cases), "score": round(count / len(cases), 4) if cases else 0.0,
+        "new_misses": sum(1 for case in cases if case["new_miss"]),
+        "cases": cases, "state": hits,
+    }
+
+
+def human(result: dict) -> str:
+    if result.get("status") != "ok":
+        return f"recall benchmark WARN: {result.get('error', 'unknown error')}"
+    lines = ["recall benchmark:"]
+    for case in result["cases"]:
+        mark = "HIT " if case["hit"] else "MISS"
+        fresh = " NEW" if case["new_miss"] else ""
+        ids = ", ".join(item["id"] for item in case["top"]) or "(no matches)"
+        lines.append(f"  {mark}{fresh}  {case['expect']}  <-  {ids}")
+    lines.append(
+        f"  {result['metric']}: {result['hits']}/{result['total']} "
+        f"({result['score'] * 100:.1f}%), new misses: {result['new_misses']}"
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Warn-only memory recall benchmark")
+    parser.add_argument("--fixtures")
+    parser.add_argument("--project-dir", default=os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    parser.add_argument("--memory-dir", action="append", default=[])
+    parser.add_argument("--learnings-dir", default=str(Path.home() / ".asha" / "learnings"))
+    parser.add_argument("--state-file", default=str(Path.home() / ".cache" / "asha" / "recall-bench.json"))
+    parser.add_argument("--no-state", action="store_true")
+    parser.add_argument("--k", type=int, default=5)
+    parser.add_argument("--format", choices=("human", "json", "both"), default="both")
+    args = parser.parse_args()
+
+    try:
+        project = Path(args.project_dir).resolve()
+        fixture_path, global_fixtures = find_fixtures(project, args.fixtures)
+        fixtures = load_fixtures(fixture_path)
+        memory_dirs = ([Path(item).expanduser() for item in args.memory_dir]
+                       if args.memory_dir else
+                       discover_memory_dirs(project, all_projects=global_fixtures))
+        entries = build_entries(memory_dirs, Path(args.learnings_dir).expanduser())
+        state_path = Path(args.state_file).expanduser()
+        prior = {} if args.no_state else _load_prior(state_path)
+        result = run_benchmark(fixtures, entries, k=max(1, args.k), prior=prior)
+        result.update({"fixtures": str(fixture_path), "entries": len(entries)})
+        if not args.no_state:
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = state_path.with_name(f".{state_path.name}.tmp.{os.getpid()}")
+            tmp.write_text(json.dumps({"hits": result.pop("state")}, indent=2) + "\n", encoding="utf-8")
+            os.replace(tmp, state_path)
+        else:
+            result.pop("state", None)
+    except Exception as exc:  # warn-only boundary: malformed fixtures cannot block save
+        result = {"status": "warning", "error": str(exc), "hits": 0, "total": 0,
+                  "score": 0.0, "new_misses": 0, "cases": []}
+
+    if args.format in {"human", "both"}:
+        print(human(result), file=sys.stderr if args.format == "both" else sys.stdout)
+    if args.format in {"json", "both"}:
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/session/tools/save-session.sh
+++ b/plugins/session/tools/save-session.sh
@@ -214,7 +214,7 @@ synthesize_from_events() {
 
     if [[ -f "$PATTERN_ANALYZER" && -n "$PYTHON_CMD" ]]; then
         # Use pattern_analyzer for consistent Four Questions output format
-        RESULT=$(ASHA_SAVE_STRICT=1 "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --days "$days" || echo '{"status":"error"}')
+        RESULT=$(ASHA_SAVE_STRICT=1 "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --project-dir "$PROJECT_DIR" --days "$days" || echo '{"status":"error"}')
         # Read the generated activeContext.md
         if [[ -f "$ACTIVE_CONTEXT" ]]; then
             cat "$ACTIVE_CONTEXT"
@@ -331,7 +331,7 @@ from_transcript_mode() {
 
     log "Running synthesis against transcript-derived events..."
     ASHA_EVENTS_FILE="$SIDE_FILE" ASHA_SAVE_STRICT=1 ASHA_SESSION_ID="$SID" ASHA_HARNESS="$HARNESS" \
-        "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --days 7 \
+        "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --project-dir "$PROJECT_DIR" --days 7 \
         > /tmp/synth-from-transcript.json 2>&1 \
         || log "synthesis returned non-zero (see /tmp/synth-from-transcript.json)"
 
@@ -359,12 +359,14 @@ automatic_mode() {
 
     if [[ -f "$PATTERN_ANALYZER" && -n "$PYTHON_CMD" ]]; then
         log "Running pattern analysis and synthesis..."
-        RESULT=$(ASHA_SAVE_STRICT=1 "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --days 7 || echo '{"status":"error"}')
+        RESULT=$(ASHA_SAVE_STRICT=1 "$PYTHON_CMD" "$PATTERN_ANALYZER" synthesize --project-dir "$PROJECT_DIR" --days 7 || echo '{"status":"error"}')
 
         # Log results
         EVENTS_COUNT=$(echo "$RESULT" | "$PYTHON_CMD" -c "import sys,json; print(json.load(sys.stdin).get('events_processed',0))" 2>/dev/null || echo "0")
         PATTERNS_COUNT=$(echo "$RESULT" | "$PYTHON_CMD" -c "import sys,json; print(json.load(sys.stdin).get('patterns_found',0))" 2>/dev/null || echo "0")
+        DRIFT=$(echo "$RESULT" | "$PYTHON_CMD" -c "import sys,json; print(json.load(sys.stdin).get('drift') or 'UNCLASSIFIABLE')" 2>/dev/null || echo "UNCLASSIFIABLE")
         log "Synthesis complete: $EVENTS_COUNT events processed, $PATTERNS_COUNT patterns found"
+        log "Drift classification: $DRIFT"
     else
         log "Pattern analyzer not available, skipping synthesis"
     fi
@@ -379,6 +381,17 @@ automatic_mode() {
         [[ "${ASHA_LEARNINGS_VALIDATE:-warn}" == "strict" ]] && VFLAG="--strict"
         "$PYTHON_CMD" "$VALIDATE" "$LEARNINGS_DIR" $VFLAG >&2 \
             || log "learnings bundle validation reported issues (non-fatal; see above)"
+    fi
+
+    # Recall quality ratchet (WARN-ONLY). Human output includes aggregate hit@5
+    # and marks misses that were hits at the previous run.
+    RECALL_BENCH="$PLUGIN_ROOT/tools/recall_bench.py"
+    if [[ -f "$RECALL_BENCH" && -n "$PYTHON_CMD" ]]; then
+        "$PYTHON_CMD" "$RECALL_BENCH" --project-dir "$PROJECT_DIR" --format human >&2 || true
+    fi
+    MEMORY_NUDGE="$PLUGIN_ROOT/tools/memory_nudge.py"
+    if [[ -f "$MEMORY_NUDGE" && -n "$PYTHON_CMD" ]]; then
+        "$PYTHON_CMD" "$MEMORY_NUDGE" stats --days 7 >&2 || true
     fi
 
     # Rotate old events (keep last 30 days in active file)

--- a/plugins/session/tools/save_preflight.py
+++ b/plugins/session/tools/save_preflight.py
@@ -183,21 +183,11 @@ def gate_active_context(project_dir: Path, save_start: Optional[datetime]) -> li
 # --------------------------------------------------------------------------- #
 # Gate 3b — WWA provenance (lead handoff belongs to THIS session)
 # --------------------------------------------------------------------------- #
-# Matches the stamp pattern_analyzer writes under the lead WWA header. Keep in
-# sync with pattern_analyzer.WWA_SESSION_MARKER.
-_WWA_HEADER_RE = re.compile(r"^##\s+What Was Accomplished\b.*$", re.MULTILINE)
-_WWA_SESSION_RE = re.compile(r"<!--\s*wwa-session:\s*(\S+?)\s*-->")
-
-
 def _lead_wwa_section(text: str) -> Optional[str]:
     """Body of the FIRST '## What Was Accomplished*' section (the lead handoff a
     cold-start session reads first), or None if there is no such section."""
-    m = _WWA_HEADER_RE.search(text)
-    if not m:
-        return None
-    start = m.end()
-    nxt = re.search(r"^##\s", text[start:], re.MULTILINE)
-    return text[start:start + nxt.start()] if nxt else text[start:]
+    import jsonl_reader  # type: ignore
+    return jsonl_reader.lead_wwa_body(text)
 
 
 def _session_event_count(project_dir: Path, current_sid: Optional[str]) -> int:
@@ -243,8 +233,8 @@ def gate_wwa_provenance(project_dir: Path, current_sid: Optional[str]) -> GateRe
     if lead is None:
         return GateResult("ac_wwa_provenance", "pass", False,
                           "no 'What Was Accomplished' section present to verify")
-    m = _WWA_SESSION_RE.search(lead)
-    stamped = m.group(1) if m else None
+    import jsonl_reader  # type: ignore
+    stamped = jsonl_reader.lead_wwa_session(ac.read_text())
     if current_sid and stamped == current_sid:
         return GateResult("ac_wwa_provenance", "pass", True,
                           f"lead WWA stamped current session {current_sid}")

--- a/tests/python/test_memory_retrieval.py
+++ b/tests/python/test_memory_retrieval.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Narrow tests for issue #8/#9 recall retrieval and nudging."""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+TOOLS = REPO / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS))
+
+import memory_nudge
+import memory_retrieval
+import recall_bench
+
+
+class RetrievalTest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="asha_recall_"))
+        self.memory = self.root / "memory"
+        self.learnings = self.root / "learnings"
+        self.memory.mkdir()
+        self.learnings.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _memory_file(self, description: str):
+        (self.memory / "MEMORY.md").write_text(
+            "- [Disk case](reference_disk_case.md) - diagnosed failure runbook\n",
+            encoding="utf-8",
+        )
+        (self.memory / "reference_disk_case.md").write_text(
+            f"---\ndescription: {description}\ntype: reference\n---\nBODY MUST NOT BE INDEXED\n",
+            encoding="utf-8",
+        )
+
+    def test_frontmatter_description_break_flips_fixture_to_miss(self):
+        self._memory_file("zephyrquartz controller saturation recovery")
+        fixture = [{"q": "zephyrquartz controller saturation", "expect": "reference_disk_case"}]
+        entries = memory_retrieval.build_entries([self.memory], self.learnings)
+        first = recall_bench.run_benchmark(fixture, entries, k=5, prior={})
+        self.assertTrue(first["cases"][0]["hit"])
+
+        self._memory_file("generic diagnosed failure runbook")
+        entries = memory_retrieval.build_entries([self.memory], self.learnings)
+        second = recall_bench.run_benchmark(fixture, entries, k=5, prior={})
+        self.assertFalse(second["cases"][0]["hit"])
+
+    def test_memory_body_is_not_indexed(self):
+        self._memory_file("generic runbook")
+        entries = memory_retrieval.build_entries([self.memory], self.learnings)
+        ranked = memory_retrieval.rank("BODY MUST NOT BE INDEXED", entries)
+        self.assertEqual(ranked, [])
+
+    def test_learning_title_description_and_trigger_are_retrievable(self):
+        (self.learnings / "narrow-scan.md").write_text(
+            "---\ntype: learning\nid: narrow-scan\ntitle: Narrow filesystem scan\n"
+            "description: Avoid galactic home traversal\ntrigger: launching recursive find\n---\nbody secret\n",
+            encoding="utf-8",
+        )
+        entries = memory_retrieval.build_entries([], self.learnings)
+        self.assertEqual(memory_retrieval.rank("galactic home traversal", entries)[0]["id"], "narrow-scan")
+
+    def test_fixture_parser_supports_documented_yaml_shape(self):
+        path = self.root / "fixtures.yaml"
+        path.write_text('- q: "some question"\n  expect: memory_id\n', encoding="utf-8")
+        self.assertEqual(recall_bench.load_fixtures(path),
+                         [{"q": "some question", "expect": "memory_id"}])
+
+    def test_cli_is_warn_only_on_bad_fixture(self):
+        path = self.root / "bad.yaml"
+        path.write_text("- q: missing expectation\n", encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(TOOLS / "recall_bench.py"), "--fixtures", str(path),
+             "--project-dir", str(self.root), "--format", "json"],
+            text=True, capture_output=True, check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(result.stdout)["status"], "warning")
+
+    def test_nudge_build_does_not_index_other_projects(self):
+        home = self.root / "home"
+        project = self.root / "project"
+        current_memory = project / "Memory"
+        current_memory.mkdir(parents=True)
+        (current_memory / "MEMORY.md").write_text(
+            "- [Current](current_safe.md) - zephyr current project\n", encoding="utf-8"
+        )
+        (current_memory / "current_safe.md").write_text(
+            "---\ndescription: zephyr current project\n---\n", encoding="utf-8"
+        )
+        other = home / ".claude" / "projects" / "-other" / "memory"
+        other.mkdir(parents=True)
+        (other / "MEMORY.md").write_text(
+            "- [Other](other_private.md) - forbidden cross project\n", encoding="utf-8"
+        )
+        (other / "other_private.md").write_text(
+            "---\ndescription: forbidden cross project\n---\n", encoding="utf-8"
+        )
+        index = self.root / "scoped-index.json"
+        with mock.patch.dict(os.environ, {"HOME": str(home)}, clear=False):
+            memory_nudge.build(SimpleNamespace(
+                project_dir=str(project), index=str(index), learnings_dir=str(self.learnings)
+            ))
+        ids = {entry.id for entry in memory_retrieval.load_index(index)}
+        self.assertIn("current_safe", ids)
+        self.assertNotIn("other_private", ids)
+        self.assertEqual(stat.S_IMODE(index.stat().st_mode), 0o600)
+
+
+class NudgeCLITest(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="asha_nudge_"))
+        self.index = self.root / "index.json"
+        self.state = self.root / "state"
+        self.log = self.root / "events.jsonl"
+        entry = memory_retrieval.Entry(
+            "reference_disk_case", "zephyrquartz disk pressure diagnosis",
+            str(self.root / "reference_disk_case.md"), "memory",
+            tuple(memory_retrieval.tokenize("zephyrquartz disk pressure diagnosis")),
+        )
+        self.index.write_text(json.dumps({"version": 1, "entries": [entry.json()]}), encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def _run(self, payload: dict, env=None):
+        command = [sys.executable, str(TOOLS / "memory_nudge.py"),
+                   "--index", str(self.index), "--state-dir", str(self.state),
+                   "--log", str(self.log), "match"]
+        return subprocess.run(command, input=json.dumps(payload), text=True,
+                              capture_output=True, env=env, check=False)
+
+    def test_exactly_one_nudge_per_id_and_session(self):
+        payload = {"session_id": "one", "tool_name": "Grep",
+                   "tool_input": {"pattern": "zephyrquartz"}}
+        first = self._run(payload)
+        second = self._run(payload)
+        self.assertEqual(first.returncode, 0)
+        self.assertIn("reference_disk_case", first.stdout)
+        self.assertEqual(second.stdout, "")
+        self.assertEqual(stat.S_IMODE(self.state.stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((self.state / "one.json").stat().st_mode), 0o600)
+
+    def test_unsupported_tool_is_silent(self):
+        result = self._run({"session_id": "one", "tool_name": "Read",
+                            "tool_input": {"file_path": "zephyrquartz"}})
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_shell_kill_switch_suppresses_nudge(self):
+        hook = REPO / "plugins" / "session" / "hooks" / "memory_nudge.sh"
+        env = os.environ.copy()
+        env.update({"ASHA_NUDGE": "0", "ASHA_NUDGE_INDEX": str(self.index)})
+        result = subprocess.run(
+            ["bash", str(hook)], input=json.dumps({"session_id": "off", "tool_name": "Grep",
+                                                   "tool_input": {"pattern": "zephyrquartz"}}),
+            text=True, capture_output=True, env=env, check=False,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_acted_read_is_logged(self):
+        payload = {"session_id": "acted", "tool_name": "Grep",
+                   "tool_input": {"pattern": "zephyrquartz"}}
+        self._run(payload)
+        acted_payload = {"session_id": "acted", "tool_name": "Read",
+                         "tool_input": {"file_path": str(self.root / "reference_disk_case.md")}}
+        command = [sys.executable, str(TOOLS / "memory_nudge.py"),
+                   "--state-dir", str(self.state), "--log", str(self.log), "acted"]
+        subprocess.run(command, input=json.dumps(acted_payload), text=True, check=True)
+        statuses = [json.loads(line)["status"] for line in self.log.read_text().splitlines()]
+        self.assertEqual(statuses, ["fired", "acted"])
+
+    def test_malformed_index_fails_open(self):
+        self.index.write_text("not json", encoding="utf-8")
+        result = self._run({"session_id": "bad", "tool_name": "Grep",
+                            "tool_input": {"pattern": "zephyrquartz"}})
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_save_drift_classifier.py
+++ b/tests/python/test_save_drift_classifier.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Issue #7: classify and recover save transcript/event drift."""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+
+class SaveDriftClassifierTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_drift_"))
+        self.project = self.tmp / "project"
+        (self.project / "Memory" / "events").mkdir(parents=True)
+        (self.project / "Work" / "markers").mkdir(parents=True)
+        self.saved_env = {key: os.environ.get(key) for key in (
+            "HOME", "CLAUDE_PROJECT_DIR", "ASHA_HARNESS", "ASHA_SESSION_ID",
+            "ASHA_TRANSCRIPT_PATH", "CLAUDE_CODE_SESSION_ID", "ASHA_EVENTS_FILE",
+        )}
+        os.environ.update({
+            "HOME": str(self.tmp),
+            "CLAUDE_PROJECT_DIR": str(self.project),
+            "ASHA_HARNESS": "claude",
+            "ASHA_SESSION_ID": "sess-current",
+            "CLAUDE_CODE_SESSION_ID": "sess-current",
+        })
+        os.environ.pop("ASHA_EVENTS_FILE", None)
+        for module in ("pattern_analyzer", "jsonl_reader", "save_preflight"):
+            sys.modules.pop(module, None)
+        import pattern_analyzer  # type: ignore
+        import save_preflight  # type: ignore
+        self.pa = pattern_analyzer
+        self.sp = save_preflight
+
+    def tearDown(self):
+        for key, value in self.saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _transcript(self, path: Path, sid: str, tools=("Read",), prompt="Inspect server state"):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        rows = [
+            {"type": "file-history-snapshot", "sessionId": sid, "timestamp": ts},
+            {"type": "last-prompt", "lastPrompt": prompt, "sessionId": sid},
+        ]
+        for index, tool in enumerate(tools):
+            args = {"command": "git status"} if tool == "Bash" else {
+                "file_path": str(self.project / "src" / "file.py"),
+                "old_string": "a", "new_string": "b",
+            }
+            rows.append({
+                "type": "assistant", "timestamp": ts, "sessionId": sid,
+                "cwd": str(self.project),
+                "message": {"content": [{
+                    "type": "tool_use", "id": f"tool-{index}",
+                    "name": tool, "input": args,
+                }]},
+            })
+        path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+        return path
+
+    def _exact_path(self, sid: str) -> Path:
+        slug = str(self.project.resolve()).replace("/", "-")
+        return self.tmp / ".claude" / "projects" / slug / f"{sid}.jsonl"
+
+    def _write_prior_wwa(self, sid="sess-foreign"):
+        (self.project / "Memory" / "activeContext.md").write_text(
+            "# Active Context\n\n"
+            "## What Was Accomplished (prior)\n\n"
+            f"<!-- wwa-session: {sid} -->\n- prior work\n\n"
+            "## Next Steps\n\n- [ ] retain this\n"
+        )
+
+    def test_wrong_transcript_auto_pins_exact_current_session(self):
+        foreign = self._transcript(self.tmp / "foreign.jsonl", "sess-foreign", ("Edit",))
+        correct = self._transcript(self._exact_path("sess-current"), "sess-current", ("Edit",))
+        os.environ["ASHA_TRANSCRIPT_PATH"] = str(foreign)
+        self._write_prior_wwa("sess-prior")
+
+        decision = self.pa.classify_drift(self.project)
+
+        self.assertEqual(decision.classification, "WRONG_TRANSCRIPT")
+        self.assertEqual(decision.identity.transcript_path, correct)
+
+        result = self.pa.run_synthesis(
+            session_id="sess-current", project_dir=self.project, skip_eval=True
+        )
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["drift"], "WRONG_TRANSCRIPT→auto-pinned")
+        self.assertEqual(
+            self.sp.gate_session_integrity(self.project, "sess-current").status, "pass"
+        )
+        self.assertEqual(
+            self.sp.gate_wwa_provenance(self.project, "sess-current").status, "pass"
+        )
+        import jsonl_reader  # type: ignore
+        self.assertEqual(
+            jsonl_reader.resolve_identity(self.project).transcript_path,
+            correct,
+            "post-hoc preflight identity resolution must retain the auto-pin",
+        )
+
+    def test_exact_path_and_event_stamps_classify_clean(self):
+        transcript = self._transcript(
+            self._exact_path("sess-current"), "sess-current", ("Edit",)
+        )
+        os.environ["ASHA_TRANSCRIPT_PATH"] = str(transcript)
+
+        decision = self.pa.classify_drift(self.project)
+
+        self.assertEqual(decision.classification, "CLEAN")
+        self.assertFalse(decision.needs_minimal_wwa)
+
+    def test_bash_only_session_gets_stamped_minimal_lead_wwa(self):
+        transcript = self._transcript(
+            self._exact_path("sess-current"), "sess-current", ("Bash", "Read")
+        )
+        os.environ["ASHA_TRANSCRIPT_PATH"] = str(transcript)
+        self._write_prior_wwa()
+
+        result = self.pa.run_synthesis(
+            session_id="sess-current", project_dir=self.project, skip_eval=True
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("NO_EDIT_EVENTS", result["drift"])
+        text = (self.project / "Memory" / "activeContext.md").read_text()
+        self.assertEqual(self.sp._lead_wwa_section(text).count("wwa-session: sess-current"), 1)
+        self.assertIn("Tool activity: Bash, Read.", text)
+        self.assertIn("wwa-session: sess-foreign", text)
+        self.assertEqual(
+            self.sp.gate_wwa_provenance(self.project, "sess-current").status, "pass"
+        )
+
+    def test_concurrent_session_is_preserved_below_new_lead(self):
+        transcript = self._transcript(
+            self._exact_path("sess-current"), "sess-current", ("Edit",)
+        )
+        os.environ["ASHA_TRANSCRIPT_PATH"] = str(transcript)
+        self._write_prior_wwa()
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        (self.project / "Memory" / "events" / "events.jsonl").write_text(json.dumps({
+            "timestamp": now, "session_id": "sess-foreign", "subtype": "decision",
+        }) + "\n")
+
+        result = self.pa.run_synthesis(
+            session_id="sess-current", project_dir=self.project, skip_eval=True
+        )
+
+        self.assertEqual(result["drift"], "CONCURRENT→prepended-preserving-concurrent")
+        text = (self.project / "Memory" / "activeContext.md").read_text()
+        self.assertLess(text.index("wwa-session: sess-current"), text.index("wwa-session: sess-foreign"))
+        self.assertIn("retain this", text)
+
+    def test_unclassifiable_mismatch_without_exact_transcript_hard_fails(self):
+        foreign = self._transcript(self.tmp / "foreign.jsonl", "sess-foreign", ("Edit",))
+        os.environ["ASHA_TRANSCRIPT_PATH"] = str(foreign)
+
+        with self.assertRaisesRegex(RuntimeError, "UNCLASSIFIABLE"):
+            self.pa.classify_drift(self.project)
+
+    def test_project_save_lock_serializes_processes(self):
+        script = (
+            "import sys; from pathlib import Path; "
+            f"sys.path.insert(0, {str(TOOLS_DIR)!r}); "
+            "import pattern_analyzer as pa; "
+            "\nwith pa._project_save_lock(Path(sys.argv[1])):\n print('acquired', flush=True)"
+        )
+        env = os.environ.copy()
+        env["CLAUDE_PROJECT_DIR"] = str(self.project)
+        with self.pa._project_save_lock(self.project):
+            child = subprocess.Popen(
+                [sys.executable, "-c", script, str(self.project)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            time.sleep(0.15)
+            self.assertIsNone(child.poll(), "second save must wait for the project lock")
+        stdout, stderr = child.communicate(timeout=3)
+        self.assertEqual(child.returncode, 0, stderr)
+        self.assertEqual(stdout.strip(), "acquired")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -25,6 +25,36 @@ run() { # forwards to drift-check with sandbox HOME
     bash "$REPO_ROOT/bin/asha-drift-check.sh" "$@"
 }
 
+# BSD wc pads counts with leading whitespace. The stat shim rejects GNU -c and
+# implements BSD -f %m so this fixture also catches GNU-only mtime reads if they
+# return to the doctor. Current command-skill checks compare rendered bytes and
+# therefore do not need stat at all.
+PORTABLE_BIN="$SANDBOX/portable-bin"
+mkdir -p "$PORTABLE_BIN"
+REAL_WC="$(command -v wc)"
+cat > "$PORTABLE_BIN/wc" <<EOF
+#!/usr/bin/env bash
+out="\$("$REAL_WC" "\$@")"
+printf '%8s\n' "\$out"
+EOF
+cat > "$PORTABLE_BIN/stat" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+  exit 64
+fi
+if [[ "${1:-}" == "-f" && "${2:-}" == "%m" && $# -eq 3 ]]; then
+  python3 -c 'import os, sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$3"
+  exit
+fi
+exit 64
+EOF
+chmod +x "$PORTABLE_BIN/wc" "$PORTABLE_BIN/stat"
+
+run_portable() { # run with BSD-like wc/stat behavior on every host
+  env -i HOME="$SANDBOX" PATH="$PORTABLE_BIN:$PATH" USER="${USER:-test}" \
+    bash "$REPO_ROOT/bin/asha-drift-check.sh" "$@"
+}
+
 # ---------------------------------------------------------------------------
 echo "--- fixture: real copilot install into sandbox HOME ---"
 mkdir -p "$SANDBOX/.copilot"
@@ -133,6 +163,34 @@ bash "$REPO_ROOT/bin/asha" doctor --help >/dev/null 2>&1 \
   || fail "asha doctor --help exits 0"
 bash "$REPO_ROOT/bin/asha" doctor bogus >/dev/null 2>&1; rc=$?
 [[ $rc -eq 2 ]] && ok "asha doctor bogus exits 2" || fail "asha doctor bogus exits 2 (got $rc)"
+
+# ---------------------------------------------------------------------------
+echo "--- test 5: BSD userland compatibility ---"
+out="$(run_portable --target copilot 2>&1)"; rc=$?
+if [[ $rc -eq 0 ]] && grep -q "no CLAUDE_PLUGIN_ROOT in plugin markdown" <<<"$out"; then
+  ok "BSD-padded wc count does not cause a false repo-state failure"
+else
+  fail "BSD-padded wc count does not cause a false repo-state failure (rc=$rc)"
+fi
+if grep -Eq '^FAIL[[:space:]]+0 CLAUDE_PLUGIN_ROOT refs remain' <<<"$out"; then
+  fail "healthy BSD-like run does not emit FAIL 0"
+else
+  ok "healthy BSD-like run does not emit FAIL 0"
+fi
+
+echo "corrupted on BSD fixture" > "$stale_md"
+touch "$stale_md"
+out="$(run_portable --target copilot 2>&1 || true)"
+grep -q "command-skill content drifted" <<<"$out" \
+  && ok "drifted command-skill is detected without GNU stat" \
+  || fail "drifted command-skill is detected without GNU stat"
+out="$(run_portable --target copilot --fix 2>&1 || true)"
+grep -q "FIXED  regenerated drifted command-skill" <<<"$out" \
+  && ok "--fix repairs a drifted command-skill without GNU stat" \
+  || fail "--fix repairs a drifted command-skill without GNU stat"
+run_portable --target copilot >/dev/null 2>&1 \
+  && ok "BSD-like post-fix re-run is clean" \
+  || fail "BSD-like post-fix re-run is clean"
 
 echo ""
 echo "test-doctor: $PASS passed, $FAIL failed"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -2334,6 +2334,7 @@ tomllib.loads(text)
 assert '[[hooks.PreToolUse]]' in text
 assert '[[hooks.PreToolUse.hooks]]' in text
 assert 'type = "command"' in text
+assert 'memory_nudge.sh' not in text, 'Claude-only nudge leaked into Codex hooks'
 rule_text = rules.read_text()
 assert 'prefix_rule(' in rule_text
 assert 'pattern = ["git", "reset", "--hard"]' in rule_text
@@ -2361,6 +2362,44 @@ if [[ $CODEX_OK -eq 1 ]]; then
 else
     echo -e "${RED}FAIL${NC}"
     echo "  codex installer mismatch:$CODEX_WHY"
+    FAILED=$((FAILED + 1))
+fi
+
+# ============================================================================
+# Test 106a: Claude-only hook selection + recall fixture bootstrap
+# ============================================================================
+echo -n "Test 106a: Claude installs nudge and recall fixtures without metadata leakage... "
+CLAUDE_TMP="$(mktemp -d)"
+CLAUDE_OK=1
+CLAUDE_WHY=""
+mkdir -p "$CLAUDE_TMP/.claude"
+printf '{}\n' > "$CLAUDE_TMP/.claude/settings.json"
+if ! HOME="$CLAUDE_TMP" CLAUDE_CONFIG_DIR="$CLAUDE_TMP/.claude" \
+    "$REPO_ROOT/install.sh" --target claude --only session \
+    >/dev/null 2>"$CLAUDE_TMP/install.err"; then
+    CLAUDE_OK=0
+    CLAUDE_WHY=" install-failed:$(cat "$CLAUDE_TMP/install.err")"
+elif ! python3 - "$CLAUDE_TMP" <<'PY' >/dev/null 2>"$CLAUDE_TMP/check.err"
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+data = json.loads((root / ".claude/settings.json").read_text())
+groups = [g for event in data.get("hooks", {}).values() for g in event]
+entries = [h for group in groups for h in group.get("hooks", [])]
+assert any("memory_nudge.sh" in h.get("command", "") for h in entries)
+assert not any("_asha_harnesses" in group for group in groups)
+assert (root / ".asha/recall_fixtures.yaml").is_file()
+PY
+then
+    CLAUDE_OK=0
+    CLAUDE_WHY=" selection-check-failed:$(cat "$CLAUDE_TMP/check.err")"
+fi
+rm -rf "$CLAUDE_TMP"
+if [[ $CLAUDE_OK -eq 1 ]]; then
+    echo -e "${GREEN}PASS${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "  claude hook selection mismatch:$CLAUDE_WHY"
     FAILED=$((FAILED + 1))
 fi
 


### PR DESCRIPTION
## What changed

- Fix macOS doctor portability and add BSD-userland regression coverage.
- Classify save transcript/event drift before synthesis, auto-pin the correct transcript, recover Bash-only handoffs, preserve concurrent handoffs, serialize saves, and publish event/context files atomically.
- Add a deterministic question-to-memory recall benchmark with a 12/12 initial hit@5 baseline and warn-only `/save` integration.
- Add Claude-only mid-session memory nudges with project isolation, secure private state, deduplication, rate caps, kill switch, acted-on metrics, and bounded latency.
- Add harness-aware hook rendering and installer coverage for Claude and Codex.

## Why

The save pipeline detected known provenance failures but required manual recovery. Memory retrieval had no repeatable quality metric, and relevant authored memories could remain undiscovered after a mid-session task pivot. The doctor also produced false failures on BSD userland.

## Impact

Known save drift classes now recover automatically whilst unclassifiable states still fail closed. Recall regressions become measurable, and Claude can suggest relevant current-project memories without crossing project trust boundaries. Codex and Copilot retain their native harness behavior.

## Validation

- `./tests/run-tests.sh`: 11 suites passed, 0 failed
- Python unit tests: 140 passed
- Hook tests: 86 passed
- Recall baseline: 12/12 hit@5
- Nudge latency sample: 60 ms p95
- `./bin/asha-drift-check.sh --target codex`: pass
- `./bin/asha-drift-check.sh --target claude`: pass
- Code review: SHIP
- Security review: SHIP

Closes #6
Closes #7
Closes #8
Closes #9