### PR TITLE
fix: restore macOS and Copilot compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ asha/
 Run the full test suite:
 
 ```bash
+python3 -m pip install -r requirements.txt
 ./tests/run-tests.sh
 ```
 
@@ -516,6 +517,14 @@ Individual test suites:
 ./tests/validate-versions.sh   # Version consistency
 ./tests/test-hooks.sh          # Hook handlers
 python3 -m unittest discover -s tests/python -v  # Python tests
+```
+
+The authenticated Copilot runtime canary is opt-in because it sends one prompt
+to the local Copilot CLI. It verifies the custom-instructions directory used
+by `asha copilot`:
+
+```bash
+ASHA_LIVE_COPILOT=1 ./tests/test-copilot-live.sh
 ```
 
 ---

--- a/bin/asha-drift-check.sh
+++ b/bin/asha-drift-check.sh
@@ -55,6 +55,23 @@ warn() { echo "WARN  $1"; }          # non-failing observation
 info_line() { echo "INFO  $1"; }     # context, never a problem
 section() { echo ""; echo "── $1 ──"; }
 
+version_in_range() {
+  local version="$1" min="$2" max="$3"
+  awk -v version="$version" -v min="$min" -v max="$max" '
+    function compare(left, right, i, l, r, n, right_n) {
+      n = split(left, l, ".")
+      right_n = split(right, r, ".")
+      if (right_n > n) n = right_n
+      for (i = 1; i <= n; i++) {
+        if ((l[i] + 0) < (r[i] + 0)) return -1
+        if ((l[i] + 0) > (r[i] + 0)) return 1
+      }
+      return 0
+    }
+    BEGIN { exit !(compare(version, min) >= 0 && compare(version, max) <= 0) }
+  '
+}
+
 # --fix self-heal: regenerate a stale codex command-skill SKILL.md from its
 # source command MD. Reuses the exact generator the installer uses
 # (harnesses/codex.sh:_codex_emit_command_skill), which strips Claude-only
@@ -414,7 +431,7 @@ if [[ "$TARGET" == "codex" || "$TARGET" == "all" ]]; then
 
     # config.toml parses as TOML
     if [[ -f "$CODEX/config.toml" ]]; then
-      if python3 -c "import tomllib; tomllib.load(open('$CODEX/config.toml','rb'))" 2>/dev/null; then
+      if python3 -c "import sys; tomllib=__import__('tomllib' if sys.version_info >= (3, 11) else 'tomli'); tomllib.load(open('$CODEX/config.toml','rb'))" 2>/dev/null; then
         pass "$HOME_LABEL/.codex/config.toml parses as valid TOML"
       else
         nope "$HOME_LABEL/.codex/config.toml is invalid TOML"
@@ -437,7 +454,8 @@ if [[ "$TARGET" == "codex" || "$TARGET" == "all" ]]; then
           missing=$((missing+1))
         fi
       done < <(python3 -c "
-import tomllib
+import sys
+tomllib = __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")
 c = tomllib.load(open('$CODEX/config.toml','rb'))
 for ev, blocks in (c.get('hooks') or {}).items():
     if not isinstance(blocks, list):
@@ -457,7 +475,8 @@ for ev, blocks in (c.get('hooks') or {}).items():
       # per-entry persisted trust (hash-bound). A registered fence without the
       # flag is silently inert — the exact failure verified live 2026-07-26.
       hook_gate="$(python3 -c "
-import tomllib
+import sys
+tomllib = __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")
 c = tomllib.load(open('$CODEX/config.toml','rb'))
 events = [k for k, v in (c.get('hooks') or {}).items() if isinstance(v, list) and v]
 feats = c.get('features') or {}
@@ -617,8 +636,25 @@ if [[ "$TARGET" == "copilot" || "$TARGET" == "all" ]]; then
 
     # ───── Context (never failures) ─────
     info_line "persona loads via 'asha copilot' wrapper only (by design); plain 'copilot' is persona-free"
-    if command -v copilot >/dev/null 2>&1; then
-      info_line "copilot CLI: $(copilot --version 2>/dev/null | head -1 || echo 'version unknown')"
+    copilot_cmd="$(asha_harness_executable copilot)"
+    if command -v "$copilot_cmd" >/dev/null 2>&1; then
+      copilot_version_output="$("$copilot_cmd" --version 2>/dev/null | head -1 || true)"
+      copilot_version="$(printf '%s\n' "$copilot_version_output" | awk '
+        match($0, /[0-9]+\.[0-9]+\.[0-9]+/) {
+          print substr($0, RSTART, RLENGTH)
+          exit
+        }'
+      )"
+      info_line "copilot CLI: ${copilot_version_output:-version unknown}"
+      if [[ -n "$copilot_version" ]]; then
+        copilot_min="$(asha_copilot_verified_min_version)"
+        copilot_max="$(asha_copilot_verified_max_version)"
+        if ! version_in_range "$copilot_version" "$copilot_min" "$copilot_max"; then
+          warn "copilot CLI $copilot_version is outside the live-verified range $copilot_min-$copilot_max; run tests/test-copilot-live.sh with ASHA_LIVE_COPILOT=1 before relying on runtime hooks"
+        fi
+      else
+        warn "could not parse copilot CLI version; runtime compatibility is unverified"
+      fi
     else
       warn "copilot CLI not on PATH (install state can still be audited)"
     fi

--- a/harnesses/codex.sh
+++ b/harnesses/codex.sh
@@ -71,7 +71,7 @@ _codex_atomic_write_config() {
     return 0
   fi
   printf '%s' "$content" > "$tmp"
-  python3 -c "import tomllib,sys; tomllib.load(open(sys.argv[1],'rb'))" "$tmp" \
+  python3 -c "import sys; tomllib=__import__('tomllib' if sys.version_info >= (3, 11) else 'tomli'); tomllib.load(open(sys.argv[1],'rb'))" "$tmp" \
     || { rm -f "$tmp"; die "config.toml would be invalid TOML after write" 4; }
   mv "$tmp" "$CODEX_CONFIG_FILE"
 }
@@ -358,8 +358,9 @@ PYEOF
 # ---------------------------------------------------------------------------
 
 codex_install_rules() {
-  local content user_home
-  content="$(cat <<'EOF'
+  local content user_home rules_template
+  rules_template="$(mktemp)"
+  cat > "$rules_template" <<'EOF'
 # Managed by asha installer; do not edit.
 #
 # These native Codex rules are a coarse fallback for command approvals. Asha's
@@ -444,7 +445,8 @@ prefix_rule(
     match = ["git branch -d master"],
 )
 EOF
-)"
+  content="$(cat "$rules_template")"
+  rm -f "$rules_template"
 
   user_home="${HOME:-}"
   if [[ -z "$user_home" ]]; then
@@ -631,7 +633,8 @@ _codex_ensure_hooks_feature() {
   # Detect first (read-only) so the backup fires only when a write follows.
   local needs
   needs="$(python3 -c '
-import sys, tomllib
+import sys
+tomllib = __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")
 try:
     feats = tomllib.load(open(sys.argv[1], "rb")).get("features") or {}
 except Exception:
@@ -645,7 +648,7 @@ import os, re, sys, tempfile
 path = sys.argv[1]
 text = open(path, encoding="utf-8").read()
 try:
-    import tomllib
+    tomllib = __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")
     feats = tomllib.loads(text).get("features") or {}
 except Exception:
     sys.exit(0)  # unparseable: leave alone; the doctor TOML check reports it

--- a/harnesses/copilot.sh
+++ b/harnesses/copilot.sh
@@ -2,30 +2,10 @@
 # source-scoped library: no set flags at file scope (runs in the caller's shell)
 # Asha → GitHub Copilot harness adapter.
 #
-# Mirrors harnesses/codex.sh. Key divergences:
-#   - $COPILOT_HOME defaults to ~/.copilot (matches Codex/Claude pattern)
-#   - Hook config is JSON (~/.copilot/hooks/hooks.json), not TOML
-#   - Six lifecycle events use camelCase (sessionStart, preToolUse, ...)
-#     vs Claude's PascalCase (SessionStart, PreToolUse, ...)
-#   - Slash commands fold into skills (codex pattern)
-#
-# UNVERIFIED ASSUMPTIONS (test against live Copilot CLI):
-#   1. Hook config location: ~/.copilot/hooks/hooks.json (Q1, defaulted user-scope)
-#   2. Stop → sessionEnd event mapping (Claude has both Stop and SessionEnd)
-#      — sessionEnd itself VERIFIED live 2026-07-27 on 1.0.75: fires on clean
-#      exit with {sessionId, timestamp, cwd, reason}; reasons observed:
-#      "complete" (non-interactive -p) and "user_exit" (interactive /exit).
-#      The Stop→sessionEnd FOLD for translated hooks.json entries remains a
-#      mapping decision, not a probe result.
-#   3. PermissionRequest events have no Copilot analog (currently dropped + warned)
-#   4. Hook stdin/stdout JSON contract field names (e.g. tool_name vs toolName)
-#   5. Veto semantics — exit-code-2 vs {decision:"block"} return payload
-#   6. Agent files: generated .agent.md files with Copilot-clean frontmatter
-#   7. ${CLAUDE_PLUGIN_ROOT} substitution semantics (assumed identical to Claude)
-#
-# When verification happens, the seam to update is _copilot_translate_event,
-# the JSON-shape jq filter in copilot_install_hooks, and (for veto) any future
-# stdin/stdout shim layer between Copilot and existing hook scripts.
+# Copilot uses native skill and agent directories, rendered command-skills,
+# and three dedicated hook files: guardrails, advisory nudges, and lifecycle
+# side effects. The active hook schema is emitted by the dedicated installers
+# below; user-owned hooks.json is never modified.
 #
 # Sourced by ../install.sh and ../uninstall.sh. Expects globals from the
 # dispatcher: MARKET_ROOT, PLUGINS_DIR, NAMESPACES_FILE, DRY_RUN, FORCE,
@@ -37,54 +17,20 @@
 COPILOT_HOME="$(asha_harness_home copilot)"
 COPILOT_SKILLS_DIR="$COPILOT_HOME/skills"
 COPILOT_AGENTS_DIR="$COPILOT_HOME/agents"
+# Kept only to remove tagged artifacts emitted by pre-dedicated-hook releases.
 COPILOT_HOOKS_FILE="$COPILOT_HOME/hooks/hooks.json"
-# Asha's own guardrail hooks live in a DEDICATED file so we never touch a user's
-# hooks.json (Copilot loads every ~/.copilot/hooks/*.json).
+# Asha's own guardrail hooks live in a dedicated file so user hooks.json is
+# untouched (Copilot loads every ~/.copilot/hooks/*.json).
 COPILOT_GUARDRAILS_FILE="$COPILOT_HOME/hooks/asha-guardrails.json"
 COPILOT_NUDGES_FILE="$COPILOT_HOME/hooks/asha-nudges.json"
 COPILOT_LIFECYCLE_FILE="$COPILOT_HOME/hooks/asha-lifecycle.json"
-
-# Events Copilot is assumed to support (camelCase). UNVERIFIED — see header.
-_COPILOT_EVENTS=(sessionStart sessionEnd userPromptSubmitted preToolUse postToolUse errorOccurred)
 
 # Shared converters (skip-plugin policy, frontmatter parsing, command-skill and
 # agent emitters) — also sourced by lib/build.sh for plugin packaging.
 # shellcheck source=harnesses/copilot-common.sh
 source "$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)/copilot-common.sh"
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_copilot_is_event() {
-  local e="$1" ev
-  for ev in "${_COPILOT_EVENTS[@]}"; do [[ "$e" == "$ev" ]] && return 0; done
-  return 1
-}
-
-# Translate a Claude PascalCase event name to its Copilot camelCase equivalent.
-# Echoes the translated name on stdout, or empty string if no mapping exists
-# (caller should warn + drop the entry).
-#
-# UNVERIFIED MAPPINGS:
-#   - Stop → sessionEnd (Claude has both Stop and SessionEnd; both currently
-#     fold into the single Copilot sessionEnd event)
-#   - PermissionRequest → (dropped — no known Copilot analog)
-_copilot_translate_event() {
-  case "$1" in
-    SessionStart)      echo "sessionStart" ;;
-    SessionEnd)        echo "sessionEnd" ;;
-    Stop)              echo "sessionEnd" ;;   # UNVERIFIED — see header
-    UserPromptSubmit)  echo "userPromptSubmitted" ;;
-    PreToolUse)        echo "preToolUse" ;;
-    PostToolUse)       echo "postToolUse" ;;
-    ErrorOccurred)     echo "errorOccurred" ;;
-    PermissionRequest) echo "" ;;             # UNVERIFIED — no Copilot analog
-    *)                 echo "" ;;
-  esac
-}
-
-# Atomic write to hooks.json, validated by jq re-parse.
+# Atomic write to legacy hooks.json, validated by jq re-parse.
 _copilot_atomic_write_hooks() {
   local content="$1"
   local tmp="$COPILOT_HOOKS_FILE.tmp.$$"
@@ -220,91 +166,8 @@ copilot_install_agents() {
   done
 }
 
-# ---------------------------------------------------------------------------
-# Hooks (JSON emission, atomic, source-tagged)
-# ---------------------------------------------------------------------------
-
-# Walk one plugin's hooks.json and emit a JSON object {<event>: [groups...]}
-# with:
-#   - Claude PascalCase events translated to Copilot camelCase
-#   - ${CLAUDE_PLUGIN_ROOT} placeholders resolved to the plugin's absolute path
-#   - each hook entry tagged with "source": "asha:<ns>"
-#   - dropped events (no Copilot analog) warned to stderr
-#
-# Echoes the JSON object on stdout (empty object if nothing emitted).
-_copilot_emit_hooks_for_plugin() {
-  local abs_root="$1" hooks_json="$2" ns="$3"
-  PYTHONIOENCODING=utf-8 python3 - "$abs_root" "$hooks_json" "$ns" <<'PYEOF'
-import json, sys
-
-abs_root, hooks_json, ns = sys.argv[1], sys.argv[2], sys.argv[3]
-
-# UNVERIFIED — Stop folds into sessionEnd; PermissionRequest is dropped.
-EVENT_MAP = {
-    "SessionStart":      "sessionStart",
-    "SessionEnd":        "sessionEnd",
-    "Stop":              "sessionEnd",
-    "UserPromptSubmit":  "userPromptSubmitted",
-    "PreToolUse":        "preToolUse",
-    "PostToolUse":       "postToolUse",
-    "ErrorOccurred":     "errorOccurred",
-}
-DROP = {"PermissionRequest"}
-
-source_tag = f"asha:{ns}"
-
-def resolve_command(cmd):
-    return cmd.replace("${CLAUDE_PLUGIN_ROOT}", abs_root)
-
-with open(hooks_json) as f:
-    data = json.load(f)
-
-events = (data or {}).get("hooks") or {}
-out = {}
-dropped = []
-for event, groups in events.items():
-    if event in DROP:
-        dropped.append(event)
-        continue
-    target = EVENT_MAP.get(event)
-    if not target:
-        dropped.append(event)
-        continue
-    if not isinstance(groups, list):
-        continue
-    new_groups = []
-    for grp in groups:
-        if not isinstance(grp, dict):
-            continue
-        new_grp = {}
-        if "matcher" in grp:
-            new_grp["matcher"] = grp["matcher"]
-        new_hooks = []
-        for h in grp.get("hooks", []) or []:
-            if not isinstance(h, dict) or h.get("type") != "command":
-                continue
-            cmd = resolve_command(h.get("command", ""))
-            if not cmd:
-                continue
-            entry = dict(h)
-            entry["command"] = cmd
-            entry["source"] = source_tag
-            new_hooks.append(entry)
-        if new_hooks:
-            new_grp["hooks"] = new_hooks
-            new_groups.append(new_grp)
-    if new_groups:
-        out.setdefault(target, []).extend(new_groups)
-
-for e in dropped:
-    sys.stderr.write(f"  WARN: dropped {ns}/{e} (no Copilot event mapping)\n")
-
-sys.stdout.write(json.dumps(out))
-PYEOF
-}
-
-# Strip every Asha-tagged hook entry from the current hooks.json (or
-# bootstrap from {"hooks":{}} if missing). Echoes the cleaned JSON.
+# Strip Asha-tagged entries from legacy hooks.json releases. Echoes the
+# cleaned JSON; current installations never write this file.
 _copilot_strip_asha_entries() {
   local current
   if [[ -f "$COPILOT_HOOKS_FILE" ]]; then
@@ -327,9 +190,6 @@ _copilot_strip_asha_entries() {
   '
 }
 
-# Walk all selected plugins, build their tagged hook JSON, merge into the
-# cleaned base, and atomically write the result.
-#
 # RETIRED 2026-05-10: Asha capture (events.jsonl) now derived on-demand at
 # /save time from the host's native session log
 # (~/.copilot/session-state/<sid>/events.jsonl), via jsonl_reader. Hooks are
@@ -348,9 +208,6 @@ _copilot_strip_asha_entries() {
 # handlers (see that script's header). Soft deterrent only: Copilot bypasses
 # preToolUse under parallel tool calls (github/copilot-cli#2893).
 #
-# The legacy _copilot_emit_hooks_for_plugin / _copilot_strip_asha_entries helpers
-# above are now unused (they emitted the wrong, Claude-style schema) and may be
-# pruned in a later pass.
 copilot_install_hooks() {
   local adapter abs_adapter content
   adapter="$PLUGINS_DIR/session/hooks/handlers/copilot-policy-adapter.sh"

--- a/harnesses/registry.sh
+++ b/harnesses/registry.sh
@@ -44,6 +44,14 @@ asha_harness_executable() {
   esac
 }
 
+asha_copilot_verified_min_version() {
+  printf '%s\n' '1.0.63'
+}
+
+asha_copilot_verified_max_version() {
+  printf '%s\n' '1.0.75'
+}
+
 asha_harness_native_config() {
   local home
   home="$(asha_harness_home "$1")" || return 1

--- a/lib/uninstall.sh
+++ b/lib/uninstall.sh
@@ -136,6 +136,15 @@ parse_args() {
     || die "invalid --target '$TARGET' (expected: $(asha_harness_names_inline)|both|all)" 1
 }
 
+uninstall_total_var() {
+  case "$1" in
+    claude)  printf '%s\n' 'CLAUDE_UNINSTALL_TOTAL' ;;
+    codex)   printf '%s\n' 'CODEX_UNINSTALL_TOTAL' ;;
+    copilot) printf '%s\n' 'COPILOT_UNINSTALL_TOTAL' ;;
+    *) return 1 ;;
+  esac
+}
+
 asha_uninstall_main() {
   DRY_RUN=0; VERBOSE=0; TARGET="claude"
   parse_args "$@"
@@ -161,8 +170,11 @@ asha_uninstall_main() {
     [[ -f "$harness_script" ]] || die "harness script missing: $harness_script"
     # shellcheck disable=SC1090
     source "$harness_script"
-    # Each harness exports <T>_UNINSTALL_TOTAL.
-    local var="${t^^}_UNINSTALL_TOTAL"
+    # Each harness exports its matching uninstall total. Keep the mapping
+    # explicit: macOS ships Bash 3.2, which does not support ${var^^}.
+    local var
+    var="$(uninstall_total_var "$t")" \
+      || die "no uninstall total variable for harness: $t"
     local total_file="${TMPDIR:-/tmp}/.asha-uninstall-total.$$"
     # Failure isolation: one harness failing must never silently strand the
     # ones after it (issue #4: codex died mid-uninstall under set -e and

--- a/plugins/code/tools/issue-loop-preflight.sh
+++ b/plugins/code/tools/issue-loop-preflight.sh
@@ -43,7 +43,13 @@ command -v git >/dev/null 2>&1 || refuse "git is required and is not installed"
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
     || refuse "not inside a git repository"
-REAL_ROOT="$(realpath "$REPO_ROOT")"
+
+canonical_dir() {
+    cd -P "$1" >/dev/null 2>&1 && pwd
+}
+
+REAL_ROOT="$(canonical_dir "$REPO_ROOT")" \
+    || refuse "cannot resolve repository root: $REPO_ROOT"
 
 FLAG="$REPO_ROOT/.asha/issue-loop.json"
 [[ -f "$FLAG" ]] || refuse "project has not opted in — no .asha/issue-loop.json in $REPO_ROOT (template: plugins/code/templates/issue-loop.json)"
@@ -58,7 +64,7 @@ USER_CFG="$HOME/.asha/config.json"
 IN_LIST=false
 while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
-    e="$(realpath -m "$entry" 2>/dev/null || printf '%s' "$entry")"
+    e="$(canonical_dir "$entry" 2>/dev/null || printf '%s' "$entry")"
     [[ "$e" == "$REAL_ROOT" ]] && IN_LIST=true
 done < <(jq -r '.issue_loop.repos // [] | .[]' "$USER_CFG" 2>/dev/null || true)
 [[ "$IN_LIST" == "true" ]] || refuse "repo $REAL_ROOT is not in the ~/.asha/config.json issue_loop.repos allowlist — both sides must opt in"

--- a/plugins/session/tools/jsonl_reader.py
+++ b/plugins/session/tools/jsonl_reader.py
@@ -364,7 +364,7 @@ def resolve_identity(
 
 def _project_slug_for_claude(project_dir: Path) -> str:
     """Claude's transcript slug: cwd with '/' replaced by '-' (path-as-name)."""
-    return str(project_dir.resolve()).replace("/", "-")
+    return str(project_dir.absolute()).replace("/", "-")
 
 
 def locate_session_log(harness: str, project_dir: Optional[Path] = None) -> Optional[Path]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 # validator/visualizer (validate.py / visualize.py). Tests skip gracefully when
 # it is missing.
 PyYAML>=6.0
+tomli>=2.0; python_version < "3.11"

--- a/tests/python/test_learnings_manager_okf.py
+++ b/tests/python/test_learnings_manager_okf.py
@@ -13,6 +13,7 @@ would be invisible in production).
 import json
 import os
 import shutil
+import site
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 
 import importlib.util
 HAVE_YAML = importlib.util.find_spec("yaml") is not None
+PYTHON_USER_SITE = site.getusersitepackages()
 
 
 class OKFLearningsTestBase(unittest.TestCase):
@@ -574,9 +576,15 @@ class ValidateSmokeTests(OKFLearningsTestBase):
         self.lm.add_learning("Cat", "one", "t1", "a1", "p", "r")
         self.lm.add_learning("Cat", "two", "t2", "a2", "p", "r")
         validate = TOOLS_DIR / "validate.py"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = (
+            PYTHON_USER_SITE
+            if not env.get("PYTHONPATH")
+            else f"{PYTHON_USER_SITE}{os.pathsep}{env['PYTHONPATH']}"
+        )
         proc = subprocess.run(
             [sys.executable, str(validate), str(self.lm.LEARNINGS_DIR), "--strict"],
-            capture_output=True, text=True,
+            capture_output=True, text=True, env=env,
         )
         self.assertEqual(proc.returncode, 0, f"validate failed:\n{proc.stdout}\n{proc.stderr}")
 
@@ -633,9 +641,10 @@ class LinkTests(OKFLearningsTestBase):
         self.assertIn("beta", self._related_of("alpha"))
 
     def test_link_candidates_window(self):
-        import re as _re
         p = self.lm._learning_path("alpha")
-        p.write_text(_re.sub(r"updated: '[^']*'", "updated: '2000-01-01'", p.read_text()))
+        alpha = self.lm._parse_file(p)
+        alpha.updated = "2000-01-01"
+        self.lm._atomic_write_file(p, self.lm._render_learning(alpha))
         out = self.lm.link_candidates(days=7)
         ids = {c["id"] for c in out["candidates"]}
         self.assertNotIn("alpha", ids, "stale learning excluded from window")

--- a/tests/python/test_memory_lifecycle_policy.py
+++ b/tests/python/test_memory_lifecycle_policy.py
@@ -2,6 +2,7 @@
 """Composition tests for silence, calibration, and OpenCode policy adaptation."""
 
 import json
+import importlib
 import os
 import subprocess
 import sys
@@ -69,9 +70,26 @@ class SessionEndSilenceTests(unittest.TestCase):
 
 
 class CalibrationPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.project_tmp = tempfile.TemporaryDirectory(prefix="asha_calibration_project_")
+        project = Path(cls.project_tmp.name)
+        (project / "Memory").mkdir()
+        cls.project_env = mock.patch.dict(
+            os.environ, {"CLAUDE_PROJECT_DIR": str(project)}, clear=False
+        )
+        cls.project_env.start()
+        sys.modules.pop("pattern_analyzer", None)
+        cls.pa = importlib.import_module("pattern_analyzer")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project_env.stop()
+        sys.modules.pop("pattern_analyzer", None)
+        cls.project_tmp.cleanup()
+
     def setUp(self):
-        import pattern_analyzer  # type: ignore[reportMissingImports]
-        self.pa = pattern_analyzer
+        self.pa = type(self).pa
 
     def test_default_synthesis_policy_disables_calibration(self):
         with mock.patch.object(self.pa, "_calibration_capture_enabled", wraps=self.pa._calibration_capture_enabled) as enabled:

--- a/tests/test-copilot-live.sh
+++ b/tests/test-copilot-live.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# test-copilot-live.sh — authenticated runtime canary for Copilot CLI.
+#
+# This is deliberately opt-in: it sends one prompt to the authenticated local
+# Copilot CLI. It proves the custom-instructions directory seam used by
+# `asha copilot`; install/doctor tests cover generated local artifacts.
+set -euo pipefail
+
+if [[ "${ASHA_LIVE_COPILOT:-0}" != "1" ]]; then
+  echo "SKIP: set ASHA_LIVE_COPILOT=1 to run the authenticated Copilot runtime canary"
+  exit 0
+fi
+
+command -v copilot >/dev/null 2>&1 || {
+  echo "FAIL: copilot CLI is not on PATH" >&2
+  exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+INSTRUCTIONS="$WORK/instructions"
+SENTINEL="ASHA-COPILOT-INSTRUCTIONS-CANARY"
+mkdir -p "$INSTRUCTIONS/.github/instructions"
+cat > "$INSTRUCTIONS/.github/instructions/asha-canary.instructions.md" <<EOF
+---
+applyTo: "**"
+---
+
+When asked for the Asha Copilot instruction canary, reply with exactly:
+$SENTINEL
+EOF
+
+output="$(
+  COPILOT_HOME="$WORK/copilot" \
+  COPILOT_CUSTOM_INSTRUCTIONS_DIRS="$INSTRUCTIONS" \
+  copilot -p "What is the Asha Copilot instruction canary? Reply with the exact sentinel and no other text." \
+  </dev/null 2>&1
+)" || {
+  echo "FAIL: Copilot CLI canary invocation failed" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+}
+
+if [[ "$output" == *"$SENTINEL"* ]]; then
+  echo "PASS: Copilot loaded COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
+else
+  echo "FAIL: Copilot did not return the instruction sentinel" >&2
+  printf '%s\n' "$output" >&2
+  exit 1
+fi

--- a/tests/test-doctor.sh
+++ b/tests/test-doctor.sh
@@ -80,6 +80,31 @@ grep -q "persona loads via 'asha copilot' wrapper only" <<<"$out" \
   || fail "wrapper-scoped persona reported as INFO (by design, not failure)"
 
 # ---------------------------------------------------------------------------
+echo "--- test 1b: Copilot version outside the live-verified range warns ---"
+VERSION_BIN="$SANDBOX/version-bin"
+mkdir -p "$VERSION_BIN"
+cat > "$VERSION_BIN/copilot" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && printf 'GitHub Copilot CLI %s\n' "${ASHA_TEST_COPILOT_VERSION:?}"
+EOF
+chmod +x "$VERSION_BIN/copilot"
+run_with_copilot_version() {
+  env -i HOME="$SANDBOX" PATH="$PATH" USER="${USER:-test}" \
+    ASHA_COPILOT_CMD="$VERSION_BIN/copilot" ASHA_TEST_COPILOT_VERSION="$1" \
+    bash "$REPO_ROOT/bin/asha-drift-check.sh" --target copilot
+}
+out="$(run_with_copilot_version 1.0.75 2>&1)"
+if grep -q "outside the live-verified range" <<<"$out"; then
+  fail "verified Copilot version does not warn"
+else
+  ok "verified Copilot version does not warn"
+fi
+out="$(run_with_copilot_version 1.0.78 2>&1)"
+grep -q "outside the live-verified range 1.0.63-1.0.75" <<<"$out" \
+  && ok "newer Copilot version warns to run the live canary" \
+  || fail "newer Copilot version warns to run the live canary"
+
+# ---------------------------------------------------------------------------
 echo "--- test 2: broken copilot install fails, --fix heals what it owns ---"
 # 2a. dangling asha-rooted symlink
 ln -s "$REPO_ROOT/plugins/does-not-exist" "$SANDBOX/.copilot/skills/dangler"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -579,7 +579,7 @@ for cmd_file in "$REPO_ROOT"/plugins/*/commands/*.md; do
     # Check if file starts with ---
     if head -1 "$cmd_file" | grep -q "^---"; then
         # Extract frontmatter and validate
-        FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | tail -n +2 | head -n -1)
+        FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | sed '1d;$d')
         if ! echo "$FRONTMATTER" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)" 2>/dev/null; then
             if [[ $INVALID_FRONTMATTER -eq 0 ]]; then
                 echo -e "${RED}FAIL${NC}"
@@ -895,7 +895,7 @@ for cmd_file in "$REPO_ROOT"/plugins/*/commands/*.md; do
     # Check if file has frontmatter with description
     if head -1 "$cmd_file" | grep -q "^---"; then
         # Extract frontmatter
-        FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | tail -n +2 | head -n -1)
+        FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | sed '1d;$d')
         if ! echo "$FRONTMATTER" | grep -q "description:"; then
             if [[ $MISSING_DESC -eq 0 ]]; then
                 echo -e "${RED}FAIL${NC}"
@@ -961,7 +961,7 @@ for template in "$TEMPLATES_DIR"/*.md; do
     fi
 
     if head -1 "$template" | grep -q "^---"; then
-        FRONTMATTER=$(sed -n '1,/^---$/p' "$template" | tail -n +2 | head -n -1)
+        FRONTMATTER=$(sed -n '1,/^---$/p' "$template" | sed '1d;$d')
         if ! echo "$FRONTMATTER" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)" 2>/dev/null; then
             if [[ $INVALID_TEMPLATES -eq 0 ]]; then
                 echo -e "${RED}FAIL${NC}"
@@ -1015,7 +1015,8 @@ fi
 # inside the SAME plugin's commands/ dir.
 echo -n "Test 52: No duplicate command names within a plugin... "
 DUPLICATES=0
-declare -A CMD_NAMES
+CMD_NAMES_FILE="$(mktemp)"
+: > "$CMD_NAMES_FILE"
 
 for cmd_file in "$REPO_ROOT"/plugins/*/commands/*.md; do
     [[ ! -f "$cmd_file" ]] && continue
@@ -1023,16 +1024,17 @@ for cmd_file in "$REPO_ROOT"/plugins/*/commands/*.md; do
     plugin_name=$(basename "$(dirname "$(dirname "$cmd_file")")")
     key="${plugin_name}/${cmd_name}"
 
-    if [[ -n "${CMD_NAMES[$key]:-}" ]]; then
+    if grep -Fqx -- "$key" "$CMD_NAMES_FILE"; then
         if [[ $DUPLICATES -eq 0 ]]; then
             echo -e "${RED}FAIL${NC}"
         fi
         echo "  Duplicate command '$cmd_name' inside plugin '$plugin_name'"
         DUPLICATES=$((DUPLICATES + 1))
     else
-        CMD_NAMES[$key]="$plugin_name"
+        printf '%s\n' "$key" >> "$CMD_NAMES_FILE"
     fi
 done
+rm -f "$CMD_NAMES_FILE"
 
 if [[ $DUPLICATES -eq 0 ]]; then
     echo -e "${GREEN}PASS${NC}"
@@ -1279,7 +1281,7 @@ for cmd_file in "$REPO_ROOT"/plugins/*/commands/*.md; do
     if grep -q "Task tool\|launch.*agent\|spawn.*agent" "$cmd_file"; then
         # Extract frontmatter and check for allowed-tools
         if head -1 "$cmd_file" | grep -q "^---"; then
-            FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | tail -n +2 | head -n -1)
+            FRONTMATTER=$(sed -n '1,/^---$/p' "$cmd_file" | sed '1d;$d')
             if ! echo "$FRONTMATTER" | grep -q "allowed-tools"; then
                 # This is a warning, not a hard failure
                 : # silently pass
@@ -2150,7 +2152,7 @@ EOF
 export CLAUDE_PROJECT_DIR="$TEST92C_DIR"
 export CLAUDE_PLUGIN_ROOT="$REPO_ROOT/plugins/session"
 
-OUTPUT=$(echo '{"prompt": "x"}' | HOME="$TEST92C_DIR" "$REPO_ROOT/plugins/session/hooks/handlers/nudge-engine.sh" UserPromptSubmit 2>/dev/null || true)
+OUTPUT=$(echo '{"prompt": "x"}' | env -u COPILOT_CLI HOME="$TEST92C_DIR" "$REPO_ROOT/plugins/session/hooks/handlers/nudge-engine.sh" UserPromptSubmit 2>/dev/null || true)
 rm -rf "$TEST92C_DIR"
 
 if [[ "$OUTPUT" == "USER-LAYER-FIRED" ]]; then
@@ -2743,7 +2745,8 @@ if ! CODEX_HOME="$CODEX_TMP" ASHA_HOME="$CODEX_TMP/asha" ASHA_CONFIG="$CODEX_TMP
     CODEX_OK=0
     CODEX_WHY=" install-failed:$(cat "$CODEX_TMP/install.err")"
 elif ! python3 - "$CODEX_TMP/config.toml" "$CODEX_TMP/rules/asha.rules" "$CODEX_TMP/agents/session-loop-operator.toml" "$CODEX_TMP/skills/session-save/SKILL.md" "$CODEX_USER_HOME" <<'PY' >/dev/null 2>"$CODEX_TMP/check.err"
-import pathlib, sys, tomllib
+import pathlib, sys
+tomllib = __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")
 config = pathlib.Path(sys.argv[1])
 rules = pathlib.Path(sys.argv[2])
 agent = pathlib.Path(sys.argv[3])
@@ -2812,7 +2815,8 @@ if ! CODEX_HOME="$CODEX_TMP2" ASHA_HOME="$CODEX_TMP2/asha" ASHA_CONFIG="$CODEX_T
     echo -e "${RED}FAIL${NC}"
     echo "  install failed: $(cat "$CODEX_TMP2/install.err")"
 elif ! python3 -c "
-import tomllib, sys
+import sys
+tomllib = __import__('tomllib' if sys.version_info >= (3, 11) else 'tomli')
 parsed = tomllib.load(open('$CODEX_TMP2/config.toml', 'rb'))
 assert parsed.get('features', {}).get('hooks') is False, 'explicit hooks = false must survive install'
 " 2>"$CODEX_TMP2/check.err"; then
@@ -2863,7 +2867,8 @@ PY
         "$REPO_ROOT/install.sh" --target codex --only session >/dev/null 2>&1; then
         CODEX_OK3=0; CODEX_WHY3=" reinstall-failed"
     elif ! python3 -c "
-import tomllib
+import sys
+tomllib = __import__('tomllib' if sys.version_info >= (3, 11) else 'tomli')
 parsed = tomllib.load(open('$CODEX_TMP3/config.toml', 'rb'))
 state = (parsed.get('hooks') or {}).get('state') or {}
 assert any(v.get('trusted_hash') == 'sha256:cafe1234' for v in state.values() if isinstance(v, dict)), \

--- a/tests/test-install.sh
+++ b/tests/test-install.sh
@@ -23,6 +23,7 @@ command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available" >&2; exit 0; }
 
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
+PYTHON_USER_SITE="$(python3 -c 'import site; print(site.getusersitepackages())')"
 
 reset_sandbox() {
   rm -rf "$SANDBOX"
@@ -37,6 +38,7 @@ seed_native_configs() {
 
 run_install() {
   env -u XDG_CONFIG_HOME -u XDG_DATA_HOME HOME="$SANDBOX" \
+    PYTHONPATH="$PYTHON_USER_SITE${PYTHONPATH:+:$PYTHONPATH}" \
     bash "$REPO_ROOT/install.sh" "$@"
 }
 

--- a/tests/test-issue-loop.sh
+++ b/tests/test-issue-loop.sh
@@ -126,13 +126,15 @@ fi
 
 echo -n "Test IL-2: preflight refuses when project flag exists but enabled=false... "
 enable_repo "$REPO_A"
-sed -i 's/"enabled": true/"enabled": false/' "$REPO_A/.asha/issue-loop.json"
+sed 's/"enabled": true/"enabled": false/' "$REPO_A/.asha/issue-loop.json" > "$REPO_A/.asha/issue-loop.json.tmp"
+mv "$REPO_A/.asha/issue-loop.json.tmp" "$REPO_A/.asha/issue-loop.json"
 if run_preflight "$HOME_A" "$REPO_A"; then
     fail "preflight exited 0 with enabled=false"
 else
     pass
 fi
-sed -i 's/"enabled": false/"enabled": true/' "$REPO_A/.asha/issue-loop.json"
+sed 's/"enabled": false/"enabled": true/' "$REPO_A/.asha/issue-loop.json" > "$REPO_A/.asha/issue-loop.json.tmp"
+mv "$REPO_A/.asha/issue-loop.json.tmp" "$REPO_A/.asha/issue-loop.json"
 
 echo -n "Test IL-3: preflight refuses when repo is not in the user allowlist... "
 HOME_B="$TEST_DIR/home-b"

--- a/tests/validate-versions.sh
+++ b/tests/validate-versions.sh
@@ -21,14 +21,27 @@ NC='\033[0m'
 PASSED=0
 FAILED=0
 
+extract_version() {
+    awk '
+        /^\*\*Version\*\*:/ {
+            version = $0
+            sub(/^\*\*Version\*\*:[[:space:]]*/, "", version)
+            if (version ~ /^[0-9]+\.[0-9]+\.[0-9]+$/) {
+                print version
+            }
+            exit
+        }
+    ' "$1"
+}
+
 echo "=== Version Consistency Validator ==="
 echo "Repository: $REPO_ROOT"
 echo ""
 
 # Extract top-level versions from README and CLAUDE.md.
 # Both files are expected to declare `**Version**: X.Y.Z` near the top.
-README_VERSION=$(grep -m1 -oP '^\*\*Version\*\*:\s*\K[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/README.md" || true)
-CLAUDE_MD_VERSION=$(grep -m1 -oP '^\*\*Version\*\*:\s*\K[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/CLAUDE.md" || true)
+README_VERSION=$(extract_version "$REPO_ROOT/README.md")
+CLAUDE_MD_VERSION=$(extract_version "$REPO_ROOT/CLAUDE.md")
 
 # Test 1: README version is present and well-formed.
 echo -n "Test 1: README.md has top-level **Version** in semver form... "
@@ -91,7 +104,7 @@ CLAUDE_TABLE_MISMATCHES=0
 
 echo -n "Test 3: Per-plugin versions match README.md plugin table... "
 for plugin_readme in "$REPO_ROOT"/plugins/*/README.md; do
-    plugin_version=$(grep -m1 -oP '^\*\*Version\*\*:\s*\K[0-9]+\.[0-9]+\.[0-9]+' "$plugin_readme" || true)
+    plugin_version=$(extract_version "$plugin_readme")
     [[ -n "$plugin_version" ]] || continue
 
     plugin_dir="$(basename "$(dirname "$plugin_readme")")"
@@ -118,7 +131,7 @@ fi
 
 echo -n "Test 4: Per-plugin versions match CLAUDE.md Current Plugins table... "
 for plugin_readme in "$REPO_ROOT"/plugins/*/README.md; do
-    plugin_version=$(grep -m1 -oP '^\*\*Version\*\*:\s*\K[0-9]+\.[0-9]+\.[0-9]+' "$plugin_readme" || true)
+    plugin_version=$(extract_version "$plugin_readme")
     [[ -n "$plugin_version" ]] || continue
 
     plugin_dir="$(basename "$(dirname "$plugin_readme")")"
@@ -171,7 +184,7 @@ while IFS=$'\t' read -r detail_ns detail_version; do
         DETAIL_MISMATCHES=$((DETAIL_MISMATCHES + 1))
         continue
     fi
-    plugin_version=$(grep -m1 -oP '^\*\*Version\*\*:\s*\K[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/plugins/$plugin_dir/README.md" || true)
+    plugin_version=$(extract_version "$REPO_ROOT/plugins/$plugin_dir/README.md")
     [[ -n "$plugin_version" ]] || continue
     DETAIL_COUNT=$((DETAIL_COUNT + 1))
     if [[ "$detail_version" != "$plugin_version" ]]; then


### PR DESCRIPTION
## Summary
- restore Bash 3.2 and BSD/macOS portability across installer, uninstaller, hooks, and issue-loop tooling
- add Python 3.9 TOML compatibility and isolated-test dependency handling
- add Copilot CLI version-range doctor warnings and an opt-in live instruction canary

## Validation
- `./tests/run-tests.sh` (12 passed, 0 failed, 1 optional skip)

Fixes #18
Fixes #19
Fixes #20