### PR TITLE
feat: workspace manifest validator (workspace v1, delivery issue 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This guide helps AI assistants (like Claude) understand the asha codebase struct
 
 | Plugin | Version | Domain | Description |
 |--------|---------|--------|-------------|
-| **Session** | v1.13.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Session** | v1.14.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Asha** | v2.1.0 | Identity | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Panel System** | v5.0.0 | Research | Multi-perspective analysis with persistence and resumption — 6 agents |
 | **Code** | v1.5.0 | Development | Code review, orchestration patterns, TDD, issue-to-merge loop — 5 agents, postgres skill |
@@ -919,6 +919,14 @@ git push -u origin <branch-name>
 ---
 
 ## Version History
+
+### Session v1.14.0 (2026-08-07) — workspace manifest validator
+
+Workspace v1 delivery issue 1 (issue #31, ratified proposal): pure lexical
+`workspace_manifest.py` — typed collected errors, fail-closed, defaults,
+containment + disjointness + the `operational_root == Memory` v1 pin,
+unknown keys preserved. Filesystem checks deferred to detection/status by
+design. 38 RED-first tests.
 
 ### Session v1.13.0 (2026-08-07) — destructive-git cross-repo arm
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ They form a pipeline, not an overlap: guardrails read session_state for in-fligh
 
 | Domain | Plugin | Version | Purpose |
 |--------|--------|---------|---------|
-| **Core** | `session` | v1.13.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Core** | `session` | v1.14.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Identity** | `asha` | v2.1.0 | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Research** | `panel-system` | v5.0.0 | Multi-perspective analysis, expert panels, decision-making — 6 agents |
 | **Development** | `code` | v1.5.0 | Code review, orchestration patterns, TDD, overnight issue-to-merge loop — 5 agents |
@@ -335,7 +335,7 @@ Create a ComfyUI workflow for: txt2img with upscaling
 
 **Plugin Name**: `session`
 **Commands**: `/session:init`, `/session:save`, `/session:status`, `/session:silence`, `/session:restore`, `/session:loop`
-**Version**: 1.13.0
+**Version**: 1.14.0
 **Domain**: Core
 
 Session coordination and memory persistence — the foundation layer other plugins build on. Learnings persist as an OKF concept bundle (`~/.asha/learnings/`, one file per learning) with auto-suggested `## Related` cross-links at `/save`; see [`docs/memory-architecture.md`](docs/memory-architecture.md).
@@ -563,6 +563,18 @@ Individual plugins licensed separately. See each plugin's LICENSE file (MIT thro
 ---
 
 ## Version History
+
+### Session v1.14.0 — workspace manifest validator (2026-08-07)
+
+Workspace v1, second of the six increments to land (proposal delivery
+item 1, issue #31): `plugins/session/tools/workspace_manifest.py`, a pure lexical
+parse/validate layer for `.asha/workspace.json` — typed collected errors,
+fail-closed, schema defaults, traversal/absolute-path rejection, the
+containment and disjointness rules, and the v1 `operational_root == Memory`
+pin, with unknown keys preserved at every level. Deliberately
+filesystem-free: worktree existence and symlink canonicalization land with
+detection/status (issues 2–3). 38 table-driven tests in
+`tests/python/test_workspace_manifest.py`, written RED-first.
 
 ### Session v1.13.0 — destructive-git cross-repo arm (2026-08-07)
 

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -1,6 +1,6 @@
 # Session
 
-**Version**: 1.13.0
+**Version**: 1.14.0
 
 Session management with memory persistence, pattern extraction, and operational quality.
 

--- a/plugins/session/tools/workspace_manifest.py
+++ b/plugins/session/tools/workspace_manifest.py
@@ -7,21 +7,32 @@ docs/proposals/2026-08-06--workspace-memory.md. This layer is deliberately
 filesystem-free: git-worktree existence, symlink canonicalization, and real
 root resolution belong to detection/status (issues 2-3), where an actual
 workspace root exists. Everything here is decidable from the manifest text
-alone, so it stays a pure function with table-driven tests.
+alone, so it stays a pure, TOTAL function with table-driven tests — hostile
+input (cycles, absurd depth, huge integers, NUL/surrogate paths) yields a
+typed fail-closed error, never an exception and never a bogus success.
 
 Contract (pinned by the proposal):
   - Typed, COLLECTED errors (stable code + field + message) — not fail-fast.
   - Fail closed: any error means no manifest object is returned.
   - Schema defaults applied; unknown keys preserved at every level, never
     stripped (forward compatibility).
-  - Path rules are lexical: workspace-relative only; absolute paths,
-    backslashes, and any `..` segment reject; `.` rejects everywhere except
-    shared_git_root.
-  - Containment: operational_root must sit inside the shared_git_root tree
-    (the write root and the commit repo cannot diverge).
+  - Path rules are lexical: workspace-relative only; absolute paths and any
+    `..` segment reject; `.` rejects everywhere except shared_git_root.
+  - Containment: operational_root must sit inside the shared_git_root tree.
   - Disjointness: the three memory roots pairwise non-nesting.
-  - v1 value pin: operational_root must equal "Memory" — the save preflight,
-    hash-bound commit gate, and event machinery key on that literal path.
+  - v1 value pin: operational_root must equal "Memory".
+
+Validator strictness beyond the proposal's text (fail-closed choices,
+surfaced for Keeper ratification on PR #32 rather than invented silently):
+  - backslashes, Windows drive/UNC forms, control characters (incl. NUL,
+    newline, tab), and lone surrogates reject — a path the runtime cannot
+    even stat, or that only a Windows resolver could interpret, must fail
+    inside this typed-error boundary, not crash canonicalization later;
+  - a whitespace-only workspace_name rejects;
+  - duplicate repository paths (after normalization) reject.
+Accepted residuals: `~` and `$VAR` are treated as literal names (downstream
+consumers must never shell-interpolate manifest paths unquoted), and path
+length is unbounded here.
 """
 
 import copy
@@ -52,7 +63,7 @@ SUPPORTED_VERSION = 1
 # the commit repo, not a plane root — it participates in containment instead.
 _PLANE_ROOTS = ("operational_root", "personal_root", "shared_root")
 
-_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:($|/)")
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
 
 
 def _normalize_relpath(value: Any) -> Tuple[Optional[str], Optional[str]]:
@@ -63,20 +74,33 @@ def _normalize_relpath(value: Any) -> Tuple[Optional[str], Optional[str]]:
     """
     if not isinstance(value, str):
         return None, "wrong_type"
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        # Lone surrogates cannot reach os.stat or git at all.
+        return None, "invalid_path"
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
+        # NUL crashes every fs call; newline/tab/controls only ever appear in
+        # a manifest as an accident or an injection attempt. Fail here, typed.
+        return None, "invalid_path"
     if value.strip() == "":
         return None, "invalid_path"
+    if _WINDOWS_DRIVE.match(value):
+        # C:/x, C:\x, and drive-relative C:x all resolve against a drive,
+        # never against the workspace root.
+        return None, "absolute_path"
+    if value.startswith("\\\\"):
+        return None, "absolute_path"
+    if value.startswith("/"):
+        return None, "absolute_path"
     if "\\" in value:
         # POSIX-only manifests: a backslash is ambiguous (separator on
         # Windows, literal elsewhere) — refuse rather than guess.
         return None, "invalid_path"
-    if value.startswith("/"):
-        return None, "absolute_path"
-    if _WINDOWS_DRIVE.match(value):
-        return None, "absolute_path"
     parts = [p for p in value.split("/") if p not in ("", ".")]
     if any(p == ".." for p in parts):
-        # Interior dot-dot segments must not be laundered by normalization:
-        # "a/../../b" escapes the root even though it contains no leading "..".
+        # ANY dot-dot segment rejects, even lexically-contained "a/../b":
+        # normalization must never launder traversal.
         return None, "path_traversal"
     if not parts:
         return ".", None
@@ -87,22 +111,7 @@ def _nests(a: str, b: str) -> bool:
     return a == b or a.startswith(b + "/") or b.startswith(a + "/")
 
 
-def validate_manifest(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
-    """Validate a parsed manifest dict. Pure; never touches the filesystem.
-
-    Returns (manifest, []) on success — a deep copy with defaults applied and
-    paths normalized, unknown keys intact — or (None, errors) on any failure.
-    """
-    errors: List[ManifestError] = []
-
-    if not isinstance(data, dict):
-        return None, [
-            ManifestError("not_object", "", "manifest root must be a JSON object")
-        ]
-
-    out = copy.deepcopy(data)
-
-    # -- version -------------------------------------------------------------
+def _validate_version(data: dict, errors: List[ManifestError]) -> None:
     if "version" not in data:
         errors.append(
             ManifestError("missing_field", "version", "required field is absent")
@@ -123,7 +132,8 @@ def validate_manifest(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
             )
         )
 
-    # -- workspace_name --------------------------------------------------------
+
+def _validate_workspace_name(data: dict, errors: List[ManifestError]) -> None:
     if "workspace_name" not in data:
         errors.append(
             ManifestError(
@@ -143,199 +153,278 @@ def validate_manifest(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
             )
         )
 
-    # -- memory roots ----------------------------------------------------------
-    raw_memory = data.get("memory", {})
-    normalized_roots: dict = {}
+
+def _validate_memory_roots(
+    mem_out: dict, errors: List[ManifestError]
+) -> dict:
+    """Normalize the four root paths in place; return the normalized subset."""
+    normalized: dict = {}
+    for key in ("operational_root", "personal_root", "shared_root",
+                "shared_git_root"):
+        field = f"memory.{key}"
+        norm, err = _normalize_relpath(mem_out[key])
+        if err:
+            errors.append(
+                ManifestError(
+                    err, field, f"{key} is not a valid workspace-relative path"
+                )
+            )
+            continue
+        if norm == "." and key != "shared_git_root":
+            # Only the commit repo may be the workspace root itself; a plane
+            # root of "." would contain every other root.
+            errors.append(
+                ManifestError(
+                    "invalid_path", field,
+                    f"{key} may not be the workspace root itself",
+                )
+            )
+            continue
+        mem_out[key] = norm
+        normalized[key] = norm
+    return normalized
+
+
+def _check_root_relations(
+    roots: dict, errors: List[ManifestError]
+) -> None:
+    """v1 pin, pairwise disjointness, and containment over normalized roots."""
+    op = roots.get("operational_root")
+    if op is not None and op != V1_OPERATIONAL_ROOT:
+        errors.append(
+            ManifestError(
+                "operational_root_reserved",
+                "memory.operational_root",
+                f"operational_root must be \"{V1_OPERATIONAL_ROOT}\" in v1 — "
+                f"the save preflight, commit gate, and event machinery key on "
+                f"that literal path; other values are reserved for a future "
+                f"increment",
+            )
+        )
+
+    seen = [(k, roots[k]) for k in _PLANE_ROOTS if k in roots]
+    for i in range(len(seen)):
+        for j in range(i + 1, len(seen)):
+            (ka, va), (kb, vb) = seen[i], seen[j]
+            if _nests(va, vb):
+                errors.append(
+                    ManifestError(
+                        "roots_not_disjoint",
+                        "memory",
+                        f"{ka} ({va}) and {kb} ({vb}) overlap — a save "
+                        f"staging one root must never pick up the other",
+                    )
+                )
+
+    sgr = roots.get("shared_git_root")
+    if op is not None and sgr is not None:
+        if not (sgr == "." or op == sgr or op.startswith(sgr + "/")):
+            # The relation involves both fields — blame "memory", not the
+            # (pinned-correct) operational_root, so repair guidance points
+            # at the pair rather than the wrong knob.
+            errors.append(
+                ManifestError(
+                    "containment_violation",
+                    "memory",
+                    f"operational_root ({op}) resolves outside the "
+                    f"shared_git_root worktree ({sgr}) — the write root "
+                    f"and the commit repo cannot diverge",
+                )
+            )
+
+
+def _validate_memory(raw_memory: Any, errors: List[ManifestError]) -> Any:
     if not isinstance(raw_memory, dict):
         errors.append(
             ManifestError("wrong_type", "memory", "memory must be an object")
         )
-    else:
-        mem_out = dict(copy.deepcopy(raw_memory))
-        for key, default in MEMORY_DEFAULTS.items():
-            mem_out.setdefault(key, default)
+        return raw_memory
+    mem_out = dict(copy.deepcopy(raw_memory))
+    for key, default in MEMORY_DEFAULTS.items():
+        mem_out.setdefault(key, default)
 
-        for key in ("operational_root", "personal_root", "shared_root",
-                    "shared_git_root"):
-            field = f"memory.{key}"
-            norm, err = _normalize_relpath(mem_out[key])
-            if err:
-                errors.append(
-                    ManifestError(err, field, f"{key} is not a valid "
-                                              f"workspace-relative path")
-                )
-                continue
-            if norm == "." and key != "shared_git_root":
-                # Only the commit repo may be the workspace root itself; a
-                # plane root of "." would contain every other root.
-                errors.append(
-                    ManifestError(
-                        "invalid_path", field,
-                        f"{key} may not be the workspace root itself",
-                    )
-                )
-                continue
-            mem_out[key] = norm
-            normalized_roots[key] = norm
+    normalized = _validate_memory_roots(mem_out, errors)
+    _check_root_relations(normalized, errors)
 
-        op = normalized_roots.get("operational_root")
-        if op is not None and op != V1_OPERATIONAL_ROOT:
-            errors.append(
-                ManifestError(
-                    "operational_root_reserved",
-                    "memory.operational_root",
-                    f"operational_root must be \"{V1_OPERATIONAL_ROOT}\" in v1 "
-                    f"— the save preflight, commit gate, and event machinery "
-                    f"key on that literal path; other values are reserved for "
-                    f"a future increment",
-                )
-            )
-
-        mode = mem_out["promotion_mode"]
-        if not isinstance(mode, str):
-            errors.append(
-                ManifestError(
-                    "wrong_type", "memory.promotion_mode",
-                    "promotion_mode must be a string",
-                )
-            )
-        elif mode not in PROMOTION_MODES:
-            errors.append(
-                ManifestError(
-                    "invalid_promotion_mode",
-                    "memory.promotion_mode",
-                    f"promotion_mode must be one of {list(PROMOTION_MODES)}",
-                )
-            )
-
-        # Disjointness: none of the three plane roots may nest inside another.
-        seen = [(k, normalized_roots[k]) for k in _PLANE_ROOTS
-                if k in normalized_roots]
-        for i in range(len(seen)):
-            for j in range(i + 1, len(seen)):
-                (ka, va), (kb, vb) = seen[i], seen[j]
-                if _nests(va, vb):
-                    errors.append(
-                        ManifestError(
-                            "roots_not_disjoint",
-                            "memory",
-                            f"{ka} ({va}) and {kb} ({vb}) overlap — a save "
-                            f"staging one root must never pick up the other",
-                        )
-                    )
-
-        # Containment: the write root must live inside the commit repo.
-        sgr = normalized_roots.get("shared_git_root")
-        if op is not None and sgr is not None:
-            inside = sgr == "." or op == sgr or op.startswith(sgr + "/")
-            if not inside:
-                errors.append(
-                    ManifestError(
-                        "containment_violation",
-                        "memory.operational_root",
-                        f"operational_root ({op}) resolves outside the "
-                        f"shared_git_root worktree ({sgr}) — the write root "
-                        f"and the commit repo cannot diverge",
-                    )
-                )
-
-        out["memory"] = mem_out
-
-    # -- repositories ------------------------------------------------------------
-    raw_repos = data.get("repositories", [])
-    if not isinstance(raw_repos, list):
+    mode = mem_out["promotion_mode"]
+    if not isinstance(mode, str):
         errors.append(
             ManifestError(
-                "wrong_type", "repositories", "repositories must be a list"
+                "wrong_type", "memory.promotion_mode",
+                "promotion_mode must be a string",
+            )
+        )
+    elif mode not in PROMOTION_MODES:
+        errors.append(
+            ManifestError(
+                "invalid_promotion_mode",
+                "memory.promotion_mode",
+                f"promotion_mode must be one of {list(PROMOTION_MODES)}",
+            )
+        )
+    return mem_out
+
+
+def _validate_repo_entry(
+    entry: Any, i: int, seen_paths: dict, errors: List[ManifestError]
+) -> Any:
+    field = f"repositories[{i}]"
+    if not isinstance(entry, dict):
+        errors.append(
+            ManifestError("wrong_type", field, "repository entry must be an object")
+        )
+        return entry
+
+    # Every field is validated even when another is missing or broken —
+    # the collected-errors contract means one verdict repairs the whole entry
+    # (pass-2 finding: an early `continue` here suppressed role/docs errors).
+    if "path" not in entry:
+        errors.append(
+            ManifestError(
+                "missing_field", f"{field}.path", "repository entry requires a path"
             )
         )
     else:
-        repos_out = []
-        seen_paths: dict = {}
-        for i, entry in enumerate(copy.deepcopy(raw_repos)):
-            field = f"repositories[{i}]"
-            if not isinstance(entry, dict):
-                errors.append(
-                    ManifestError(
-                        "wrong_type", field, "repository entry must be an object"
-                    )
+        norm, err = _normalize_relpath(entry["path"])
+        if err:
+            errors.append(
+                ManifestError(
+                    err, f"{field}.path",
+                    "repository path is not a valid workspace-relative path",
                 )
-                continue
-            if "path" not in entry:
-                errors.append(
-                    ManifestError(
-                        "missing_field", f"{field}.path",
-                        "repository entry requires a path",
-                    )
+            )
+        elif norm == ".":
+            errors.append(
+                ManifestError(
+                    "repo_path_not_child", f"{field}.path",
+                    "a child repository must be a proper subdirectory of the "
+                    "workspace, not the workspace root itself",
                 )
-                repos_out.append(entry)
-                continue
-            norm, err = _normalize_relpath(entry["path"])
-            if err:
+            )
+        else:
+            if norm in seen_paths:
                 errors.append(
                     ManifestError(
-                        err, f"{field}.path",
-                        "repository path is not a valid workspace-relative path",
-                    )
-                )
-            elif norm == ".":
-                errors.append(
-                    ManifestError(
-                        "repo_path_not_child", f"{field}.path",
-                        "a child repository must be a proper subdirectory of "
-                        "the workspace, not the workspace root itself",
+                        "duplicate_repository", f"{field}.path",
+                        f"repository path {norm} already declared at "
+                        f"repositories[{seen_paths[norm]}]",
                     )
                 )
             else:
-                if norm in seen_paths:
-                    errors.append(
-                        ManifestError(
-                            "duplicate_repository", f"{field}.path",
-                            f"repository path {norm} already declared at "
-                            f"repositories[{seen_paths[norm]}]",
-                        )
-                    )
-                else:
-                    seen_paths[norm] = i
-                entry["path"] = norm
+                seen_paths[norm] = i
+            entry["path"] = norm
 
-            if "role" in entry and not isinstance(entry["role"], str):
-                errors.append(
-                    ManifestError(
-                        "wrong_type", f"{field}.role", "role must be a string"
-                    )
+    if "role" in entry and not isinstance(entry["role"], str):
+        errors.append(
+            ManifestError("wrong_type", f"{field}.role", "role must be a string")
+        )
+    if "docs" in entry:
+        dnorm, derr = _normalize_relpath(entry["docs"])
+        if derr:
+            errors.append(
+                ManifestError(
+                    derr, f"{field}.docs",
+                    "docs is not a valid workspace-relative path",
                 )
-            if "docs" in entry:
-                dnorm, derr = _normalize_relpath(entry["docs"])
-                if derr:
-                    errors.append(
-                        ManifestError(
-                            derr, f"{field}.docs",
-                            "docs is not a valid workspace-relative path",
-                        )
-                    )
-                elif dnorm == ".":
-                    errors.append(
-                        ManifestError(
-                            "invalid_path", f"{field}.docs",
-                            "docs may not be the workspace root itself",
-                        )
-                    )
-                else:
-                    entry["docs"] = dnorm
-            repos_out.append(entry)
-        out["repositories"] = repos_out
+            )
+        elif dnorm == ".":
+            errors.append(
+                ManifestError(
+                    "invalid_path", f"{field}.docs",
+                    "docs may not be the workspace root itself",
+                )
+            )
+        else:
+            entry["docs"] = dnorm
+    return entry
+
+
+def _validate_repositories(raw_repos: Any, errors: List[ManifestError]) -> Any:
+    if not isinstance(raw_repos, list):
+        errors.append(
+            ManifestError("wrong_type", "repositories", "repositories must be a list")
+        )
+        return raw_repos
+    repos_out = []
+    seen_paths: dict = {}
+    for i, entry in enumerate(copy.deepcopy(raw_repos)):
+        repos_out.append(_validate_repo_entry(entry, i, seen_paths, errors))
+    return repos_out
+
+
+def _representable(data: dict) -> bool:
+    """Probe that the structure is finite, acyclic, JSON-typed, and printable.
+
+    json.dumps raises ValueError on cycles and over-limit integers, TypeError
+    on non-JSON values, RecursionError on absurd depth — exactly the inputs
+    that would otherwise crash validation or produce an unserializable
+    "valid" manifest.
+    """
+    try:
+        json.dumps(data)
+        return True
+    except (ValueError, TypeError, RecursionError, OverflowError):
+        return False
+
+
+_UNPROCESSABLE = ManifestError(
+    "unprocessable",
+    "",
+    "manifest structure is not JSON-representable (cycle, non-JSON value, "
+    "over-limit number, or excessive depth)",
+)
+
+
+def _validate(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
+    if not isinstance(data, dict):
+        return None, [
+            ManifestError("not_object", "", "manifest root must be a JSON object")
+        ]
+    if not _representable(data):
+        return None, [_UNPROCESSABLE]
+
+    errors: List[ManifestError] = []
+    out = copy.deepcopy(data)
+
+    _validate_version(data, errors)
+    _validate_workspace_name(data, errors)
+    out["memory"] = _validate_memory(data.get("memory", {}), errors)
+    out["repositories"] = _validate_repositories(
+        data.get("repositories", []), errors
+    )
 
     if errors:
         return None, errors
     return out, []
 
 
+def validate_manifest(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
+    """Validate a parsed manifest. Pure, total; never touches the filesystem.
+
+    Returns (manifest, []) on success — a deep copy with defaults applied and
+    paths normalized, unknown keys intact — or (None, errors) on any failure.
+    """
+    try:
+        return _validate(data)
+    except RecursionError:
+        # Belt over the _representable braces: dumps and deepcopy hit their
+        # recursion ceilings at slightly different depths.
+        return None, [_UNPROCESSABLE]
+
+
+def _reject_json_constant(name: str) -> None:
+    # NaN/Infinity are Python extensions, not JSON; strict consumers of the
+    # manifest (jq, other runtimes) would reject what we accepted.
+    raise ValueError(f"non-standard JSON constant: {name}")
+
+
 def parse_manifest_text(text: str) -> Tuple[Optional[dict], List[ManifestError]]:
     """Parse manifest JSON text and validate it. Fail closed on bad JSON."""
     try:
-        data = json.loads(text)
-    except (json.JSONDecodeError, TypeError) as exc:
+        data = json.loads(text, parse_constant=_reject_json_constant)
+    except (ValueError, TypeError, RecursionError) as exc:
+        # JSONDecodeError, the int-digit limit, NaN/Infinity rejection, and
+        # parser recursion all land here — one typed verdict, no crash.
         return None, [
             ManifestError("invalid_json", "", f"manifest is not valid JSON: {exc}")
         ]
@@ -353,9 +442,10 @@ def main(argv: List[str]) -> int:
               file=sys.stderr)
         return 2
     try:
-        text = open(argv[1], "r", encoding="utf-8").read()
-    except OSError as exc:
-        print(json.dumps({"ok": False, "errors": [
+        with open(argv[1], "r", encoding="utf-8") as fh:
+            text = fh.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        print(json.dumps({"ok": False, "manifest": None, "errors": [
             {"code": "unreadable", "field": "", "message": str(exc)}]}))
         return 1
     manifest, errors = parse_manifest_text(text)

--- a/plugins/session/tools/workspace_manifest.py
+++ b/plugins/session/tools/workspace_manifest.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+workspace_manifest.py — pure lexical parse/validate of .asha/workspace.json.
+
+Workspace v1, delivery issue 1 (issue #31) of the ratified proposal
+docs/proposals/2026-08-06--workspace-memory.md. This layer is deliberately
+filesystem-free: git-worktree existence, symlink canonicalization, and real
+root resolution belong to detection/status (issues 2-3), where an actual
+workspace root exists. Everything here is decidable from the manifest text
+alone, so it stays a pure function with table-driven tests.
+
+Contract (pinned by the proposal):
+  - Typed, COLLECTED errors (stable code + field + message) — not fail-fast.
+  - Fail closed: any error means no manifest object is returned.
+  - Schema defaults applied; unknown keys preserved at every level, never
+    stripped (forward compatibility).
+  - Path rules are lexical: workspace-relative only; absolute paths,
+    backslashes, and any `..` segment reject; `.` rejects everywhere except
+    shared_git_root.
+  - Containment: operational_root must sit inside the shared_git_root tree
+    (the write root and the commit repo cannot diverge).
+  - Disjointness: the three memory roots pairwise non-nesting.
+  - v1 value pin: operational_root must equal "Memory" — the save preflight,
+    hash-bound commit gate, and event machinery key on that literal path.
+"""
+
+import copy
+import json
+import re
+import sys
+from typing import Any, List, NamedTuple, Optional, Tuple
+
+
+class ManifestError(NamedTuple):
+    code: str
+    field: str
+    message: str
+
+
+MEMORY_DEFAULTS = {
+    "operational_root": "Memory",
+    "personal_root": "memory-local",
+    "shared_root": "knowledge",
+    "shared_git_root": ".",
+    "promotion_mode": "pull-request",
+}
+PROMOTION_MODES = ("pull-request", "direct-commit")
+V1_OPERATIONAL_ROOT = "Memory"
+SUPPORTED_VERSION = 1
+
+# The three plane roots subject to pairwise disjointness. shared_git_root is
+# the commit repo, not a plane root — it participates in containment instead.
+_PLANE_ROOTS = ("operational_root", "personal_root", "shared_root")
+
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:($|/)")
+
+
+def _normalize_relpath(value: Any) -> Tuple[Optional[str], Optional[str]]:
+    """Lexically normalize a workspace-relative path.
+
+    Returns (normalized, None) or (None, error_code). "." and "./" normalize
+    to "." — callers decide whether "." is legal for their field.
+    """
+    if not isinstance(value, str):
+        return None, "wrong_type"
+    if value.strip() == "":
+        return None, "invalid_path"
+    if "\\" in value:
+        # POSIX-only manifests: a backslash is ambiguous (separator on
+        # Windows, literal elsewhere) — refuse rather than guess.
+        return None, "invalid_path"
+    if value.startswith("/"):
+        return None, "absolute_path"
+    if _WINDOWS_DRIVE.match(value):
+        return None, "absolute_path"
+    parts = [p for p in value.split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        # Interior dot-dot segments must not be laundered by normalization:
+        # "a/../../b" escapes the root even though it contains no leading "..".
+        return None, "path_traversal"
+    if not parts:
+        return ".", None
+    return "/".join(parts), None
+
+
+def _nests(a: str, b: str) -> bool:
+    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+
+
+def validate_manifest(data: Any) -> Tuple[Optional[dict], List[ManifestError]]:
+    """Validate a parsed manifest dict. Pure; never touches the filesystem.
+
+    Returns (manifest, []) on success — a deep copy with defaults applied and
+    paths normalized, unknown keys intact — or (None, errors) on any failure.
+    """
+    errors: List[ManifestError] = []
+
+    if not isinstance(data, dict):
+        return None, [
+            ManifestError("not_object", "", "manifest root must be a JSON object")
+        ]
+
+    out = copy.deepcopy(data)
+
+    # -- version -------------------------------------------------------------
+    if "version" not in data:
+        errors.append(
+            ManifestError("missing_field", "version", "required field is absent")
+        )
+    elif isinstance(data["version"], bool) or not isinstance(data["version"], int):
+        # bool is an int subclass in Python; True must not read as version 1.
+        errors.append(
+            ManifestError("wrong_type", "version", "version must be an integer")
+        )
+    elif data["version"] != SUPPORTED_VERSION:
+        errors.append(
+            ManifestError(
+                "unsupported_version",
+                "version",
+                f"version {data['version']} is not supported (this build "
+                f"understands {SUPPORTED_VERSION}); failing closed rather "
+                f"than guessing at a newer contract",
+            )
+        )
+
+    # -- workspace_name --------------------------------------------------------
+    if "workspace_name" not in data:
+        errors.append(
+            ManifestError(
+                "missing_field", "workspace_name", "required field is absent"
+            )
+        )
+    elif not isinstance(data["workspace_name"], str):
+        errors.append(
+            ManifestError(
+                "wrong_type", "workspace_name", "workspace_name must be a string"
+            )
+        )
+    elif data["workspace_name"].strip() == "":
+        errors.append(
+            ManifestError(
+                "empty_value", "workspace_name", "workspace_name must be non-empty"
+            )
+        )
+
+    # -- memory roots ----------------------------------------------------------
+    raw_memory = data.get("memory", {})
+    normalized_roots: dict = {}
+    if not isinstance(raw_memory, dict):
+        errors.append(
+            ManifestError("wrong_type", "memory", "memory must be an object")
+        )
+    else:
+        mem_out = dict(copy.deepcopy(raw_memory))
+        for key, default in MEMORY_DEFAULTS.items():
+            mem_out.setdefault(key, default)
+
+        for key in ("operational_root", "personal_root", "shared_root",
+                    "shared_git_root"):
+            field = f"memory.{key}"
+            norm, err = _normalize_relpath(mem_out[key])
+            if err:
+                errors.append(
+                    ManifestError(err, field, f"{key} is not a valid "
+                                              f"workspace-relative path")
+                )
+                continue
+            if norm == "." and key != "shared_git_root":
+                # Only the commit repo may be the workspace root itself; a
+                # plane root of "." would contain every other root.
+                errors.append(
+                    ManifestError(
+                        "invalid_path", field,
+                        f"{key} may not be the workspace root itself",
+                    )
+                )
+                continue
+            mem_out[key] = norm
+            normalized_roots[key] = norm
+
+        op = normalized_roots.get("operational_root")
+        if op is not None and op != V1_OPERATIONAL_ROOT:
+            errors.append(
+                ManifestError(
+                    "operational_root_reserved",
+                    "memory.operational_root",
+                    f"operational_root must be \"{V1_OPERATIONAL_ROOT}\" in v1 "
+                    f"— the save preflight, commit gate, and event machinery "
+                    f"key on that literal path; other values are reserved for "
+                    f"a future increment",
+                )
+            )
+
+        mode = mem_out["promotion_mode"]
+        if not isinstance(mode, str):
+            errors.append(
+                ManifestError(
+                    "wrong_type", "memory.promotion_mode",
+                    "promotion_mode must be a string",
+                )
+            )
+        elif mode not in PROMOTION_MODES:
+            errors.append(
+                ManifestError(
+                    "invalid_promotion_mode",
+                    "memory.promotion_mode",
+                    f"promotion_mode must be one of {list(PROMOTION_MODES)}",
+                )
+            )
+
+        # Disjointness: none of the three plane roots may nest inside another.
+        seen = [(k, normalized_roots[k]) for k in _PLANE_ROOTS
+                if k in normalized_roots]
+        for i in range(len(seen)):
+            for j in range(i + 1, len(seen)):
+                (ka, va), (kb, vb) = seen[i], seen[j]
+                if _nests(va, vb):
+                    errors.append(
+                        ManifestError(
+                            "roots_not_disjoint",
+                            "memory",
+                            f"{ka} ({va}) and {kb} ({vb}) overlap — a save "
+                            f"staging one root must never pick up the other",
+                        )
+                    )
+
+        # Containment: the write root must live inside the commit repo.
+        sgr = normalized_roots.get("shared_git_root")
+        if op is not None and sgr is not None:
+            inside = sgr == "." or op == sgr or op.startswith(sgr + "/")
+            if not inside:
+                errors.append(
+                    ManifestError(
+                        "containment_violation",
+                        "memory.operational_root",
+                        f"operational_root ({op}) resolves outside the "
+                        f"shared_git_root worktree ({sgr}) — the write root "
+                        f"and the commit repo cannot diverge",
+                    )
+                )
+
+        out["memory"] = mem_out
+
+    # -- repositories ------------------------------------------------------------
+    raw_repos = data.get("repositories", [])
+    if not isinstance(raw_repos, list):
+        errors.append(
+            ManifestError(
+                "wrong_type", "repositories", "repositories must be a list"
+            )
+        )
+    else:
+        repos_out = []
+        seen_paths: dict = {}
+        for i, entry in enumerate(copy.deepcopy(raw_repos)):
+            field = f"repositories[{i}]"
+            if not isinstance(entry, dict):
+                errors.append(
+                    ManifestError(
+                        "wrong_type", field, "repository entry must be an object"
+                    )
+                )
+                continue
+            if "path" not in entry:
+                errors.append(
+                    ManifestError(
+                        "missing_field", f"{field}.path",
+                        "repository entry requires a path",
+                    )
+                )
+                repos_out.append(entry)
+                continue
+            norm, err = _normalize_relpath(entry["path"])
+            if err:
+                errors.append(
+                    ManifestError(
+                        err, f"{field}.path",
+                        "repository path is not a valid workspace-relative path",
+                    )
+                )
+            elif norm == ".":
+                errors.append(
+                    ManifestError(
+                        "repo_path_not_child", f"{field}.path",
+                        "a child repository must be a proper subdirectory of "
+                        "the workspace, not the workspace root itself",
+                    )
+                )
+            else:
+                if norm in seen_paths:
+                    errors.append(
+                        ManifestError(
+                            "duplicate_repository", f"{field}.path",
+                            f"repository path {norm} already declared at "
+                            f"repositories[{seen_paths[norm]}]",
+                        )
+                    )
+                else:
+                    seen_paths[norm] = i
+                entry["path"] = norm
+
+            if "role" in entry and not isinstance(entry["role"], str):
+                errors.append(
+                    ManifestError(
+                        "wrong_type", f"{field}.role", "role must be a string"
+                    )
+                )
+            if "docs" in entry:
+                dnorm, derr = _normalize_relpath(entry["docs"])
+                if derr:
+                    errors.append(
+                        ManifestError(
+                            derr, f"{field}.docs",
+                            "docs is not a valid workspace-relative path",
+                        )
+                    )
+                elif dnorm == ".":
+                    errors.append(
+                        ManifestError(
+                            "invalid_path", f"{field}.docs",
+                            "docs may not be the workspace root itself",
+                        )
+                    )
+                else:
+                    entry["docs"] = dnorm
+            repos_out.append(entry)
+        out["repositories"] = repos_out
+
+    if errors:
+        return None, errors
+    return out, []
+
+
+def parse_manifest_text(text: str) -> Tuple[Optional[dict], List[ManifestError]]:
+    """Parse manifest JSON text and validate it. Fail closed on bad JSON."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        return None, [
+            ManifestError("invalid_json", "", f"manifest is not valid JSON: {exc}")
+        ]
+    return validate_manifest(data)
+
+
+def main(argv: List[str]) -> int:
+    """CLI: validate a manifest file, print a JSON verdict, exit 0/1.
+
+    Consumed by later increments (detection, status) and handy for humans:
+    `python3 workspace_manifest.py <path>`.
+    """
+    if len(argv) != 2:
+        print("usage: workspace_manifest.py <path-to-workspace.json>",
+              file=sys.stderr)
+        return 2
+    try:
+        text = open(argv[1], "r", encoding="utf-8").read()
+    except OSError as exc:
+        print(json.dumps({"ok": False, "errors": [
+            {"code": "unreadable", "field": "", "message": str(exc)}]}))
+        return 1
+    manifest, errors = parse_manifest_text(text)
+    verdict = {
+        "ok": manifest is not None,
+        "errors": [e._asdict() for e in errors],
+        "manifest": manifest,
+    }
+    print(json.dumps(verdict, indent=2, sort_keys=True))
+    return 0 if manifest is not None else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/python/test_workspace_manifest.py
+++ b/tests/python/test_workspace_manifest.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Tests for workspace_manifest (workspace v1, delivery issue 1 — issue #31).
+
+Pure lexical parse/validate of .asha/workspace.json per the ratified proposal
+(docs/proposals/2026-08-06--workspace-memory.md): typed collected errors,
+fail-closed (any error => no manifest), schema defaults, containment +
+disjointness + the v1 operational_root pin, unknown keys preserved. No
+filesystem access — git-worktree existence and symlink canonicalization
+belong to detection/status (issues 2-3), not this layer.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import workspace_manifest as wm  # type: ignore[reportMissingImports]  # noqa: E402
+
+
+def _codes(errors):
+    return sorted({e.code for e in errors})
+
+
+def _fields(errors):
+    return sorted({e.field for e in errors})
+
+
+MINIMAL = {"version": 1, "workspace_name": "w"}
+
+
+def _valid_full():
+    # The ratified proposal's own schema example, verbatim in structure.
+    return {
+        "version": 1,
+        "workspace_name": "example-workspace",
+        "memory": {
+            "operational_root": "Memory",
+            "personal_root": "memory-local",
+            "shared_root": "knowledge",
+            "shared_git_root": ".",
+            "promotion_mode": "pull-request",
+        },
+        "repositories": [
+            {"path": "frontend", "role": "web", "docs": "knowledge/repos/frontend"},
+            {"path": "service", "role": "api", "docs": "knowledge/repos/service"},
+        ],
+    }
+
+
+class SuccessCases(unittest.TestCase):
+    def test_minimal_manifest_applies_all_defaults(self):
+        manifest, errors = wm.validate_manifest(MINIMAL)
+        self.assertEqual(errors, [])
+        self.assertIsNotNone(manifest)
+        mem = manifest["memory"]
+        self.assertEqual(mem["operational_root"], "Memory")
+        self.assertEqual(mem["personal_root"], "memory-local")
+        self.assertEqual(mem["shared_root"], "knowledge")
+        self.assertEqual(mem["shared_git_root"], ".")
+        self.assertEqual(mem["promotion_mode"], "pull-request")
+        self.assertEqual(manifest["repositories"], [])
+
+    def test_proposal_example_validates(self):
+        manifest, errors = wm.validate_manifest(_valid_full())
+        self.assertEqual(errors, [])
+        self.assertEqual(len(manifest["repositories"]), 2)
+        self.assertEqual(manifest["repositories"][0]["path"], "frontend")
+
+    def test_parse_manifest_text_round_trip(self):
+        manifest, errors = wm.parse_manifest_text(json.dumps(_valid_full()))
+        self.assertEqual(errors, [])
+        self.assertEqual(manifest["workspace_name"], "example-workspace")
+
+    def test_paths_are_normalized(self):
+        data = _valid_full()
+        data["memory"]["operational_root"] = "./Memory/"
+        data["repositories"][0]["path"] = "frontend/"
+        data["repositories"][0]["docs"] = "./knowledge//repos/frontend"
+        manifest, errors = wm.validate_manifest(data)
+        self.assertEqual(errors, [])
+        self.assertEqual(manifest["memory"]["operational_root"], "Memory")
+        self.assertEqual(manifest["repositories"][0]["path"], "frontend")
+        self.assertEqual(
+            manifest["repositories"][0]["docs"], "knowledge/repos/frontend"
+        )
+
+    def test_direct_commit_promotion_mode_allowed(self):
+        data = _valid_full()
+        data["memory"]["promotion_mode"] = "direct-commit"
+        _, errors = wm.validate_manifest(data)
+        self.assertEqual(errors, [])
+
+    def test_unknown_keys_preserved_at_every_level(self):
+        data = _valid_full()
+        data["x_custom"] = {"nested": True}
+        data["memory"]["x_note"] = "keep me"
+        data["repositories"][0]["x_tag"] = "alpha"
+        manifest, errors = wm.validate_manifest(data)
+        self.assertEqual(errors, [])
+        self.assertEqual(manifest["x_custom"], {"nested": True})
+        self.assertEqual(manifest["memory"]["x_note"], "keep me")
+        self.assertEqual(manifest["repositories"][0]["x_tag"], "alpha")
+
+    def test_input_dict_is_not_mutated(self):
+        data = _valid_full()
+        snapshot = json.dumps(data, sort_keys=True)
+        wm.validate_manifest(data)
+        self.assertEqual(json.dumps(data, sort_keys=True), snapshot)
+
+    def test_path_with_spaces_is_legal(self):
+        data = _valid_full()
+        data["repositories"][0]["path"] = "my service"
+        _, errors = wm.validate_manifest(data)
+        self.assertEqual(errors, [])
+
+
+# Table of error cases: (name, mutate(data) -> data or raw text, expected codes,
+# optionally expected field substrings). Every case must fail CLOSED: no
+# manifest object alongside errors.
+def _mut(fn):
+    data = _valid_full()
+    fn(data)
+    return data
+
+
+class ErrorTable(unittest.TestCase):
+    def _assert_fails(self, data_or_text, expected_codes, expected_fields=()):
+        if isinstance(data_or_text, str):
+            manifest, errors = wm.parse_manifest_text(data_or_text)
+        else:
+            manifest, errors = wm.validate_manifest(data_or_text)
+        self.assertIsNone(manifest, "fail-closed: errors must mean no manifest")
+        self.assertTrue(errors, "expected at least one error")
+        for code in expected_codes:
+            self.assertIn(code, _codes(errors), f"missing code {code}: {errors}")
+        for field in expected_fields:
+            self.assertTrue(
+                any(field in e.field for e in errors),
+                f"no error on field containing '{field}': {_fields(errors)}",
+            )
+
+    def test_invalid_json(self):
+        self._assert_fails("{not json", ["invalid_json"])
+
+    def test_root_not_object(self):
+        self._assert_fails("[1, 2]", ["not_object"])
+
+    def test_version_missing(self):
+        self._assert_fails({"workspace_name": "w"}, ["missing_field"], ["version"])
+
+    def test_version_wrong_type_string(self):
+        self._assert_fails(
+            {"version": "1", "workspace_name": "w"}, ["wrong_type"], ["version"]
+        )
+
+    def test_version_bool_rejected(self):
+        # bool is an int subclass in Python; True must not read as version 1.
+        self._assert_fails(
+            {"version": True, "workspace_name": "w"}, ["wrong_type"], ["version"]
+        )
+
+    def test_version_unsupported(self):
+        self._assert_fails(
+            {"version": 2, "workspace_name": "w"},
+            ["unsupported_version"],
+            ["version"],
+        )
+
+    def test_workspace_name_missing(self):
+        self._assert_fails({"version": 1}, ["missing_field"], ["workspace_name"])
+
+    def test_workspace_name_empty(self):
+        self._assert_fails(
+            {"version": 1, "workspace_name": "  "}, ["empty_value"]
+        )
+
+    def test_workspace_name_wrong_type(self):
+        self._assert_fails({"version": 1, "workspace_name": 42}, ["wrong_type"])
+
+    def test_memory_wrong_type(self):
+        self._assert_fails(
+            {"version": 1, "workspace_name": "w", "memory": 5},
+            ["wrong_type"],
+            ["memory"],
+        )
+
+    def test_operational_root_reserved_pin(self):
+        # The proposal's own example of a v1-reserved value.
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("operational_root", "ops/memory")),
+            ["operational_root_reserved"],
+            ["memory.operational_root"],
+        )
+
+    def test_personal_root_nested_in_operational(self):
+        # Proposal disjointness example: would let `git add Memory/` stage
+        # private files.
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", "Memory/private")),
+            ["roots_not_disjoint"],
+        )
+
+    def test_shared_root_nested_in_personal(self):
+        self._assert_fails(
+            _mut(
+                lambda d: d["memory"].__setitem__(
+                    "shared_root", "memory-local/knowledge"
+                )
+            ),
+            ["roots_not_disjoint"],
+        )
+
+    def test_operational_outside_shared_git_root(self):
+        # Codex pass-1 scenario on PR #28: write root outside the commit repo.
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("shared_git_root", "shared")),
+            ["containment_violation"],
+        )
+
+    def test_absolute_path_rejected(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", "/etc/x")),
+            ["absolute_path"],
+            ["memory.personal_root"],
+        )
+
+    def test_traversal_rejected(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("shared_root", "../outside")),
+            ["path_traversal"],
+        )
+
+    def test_interior_traversal_rejected(self):
+        # Normalization must not launder interior dot-dot segments.
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][0].__setitem__("path", "a/../../b")),
+            ["path_traversal"],
+            ["repositories[0].path"],
+        )
+
+    def test_dot_rejected_for_memory_roots(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", ".")),
+            ["invalid_path"],
+        )
+
+    def test_backslash_rejected(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("shared_root", "know\\ledge")),
+            ["invalid_path"],
+        )
+
+    def test_windows_drive_path_rejected(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", "C:/mem")),
+            ["absolute_path"],
+        )
+
+    def test_promotion_mode_invalid(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("promotion_mode", "auto")),
+            ["invalid_promotion_mode"],
+        )
+
+    def test_repositories_not_list(self):
+        self._assert_fails(
+            _mut(lambda d: d.__setitem__("repositories", "frontend")),
+            ["wrong_type"],
+            ["repositories"],
+        )
+
+    def test_repository_entry_not_object(self):
+        self._assert_fails(
+            _mut(lambda d: d["repositories"].__setitem__(1, "service")),
+            ["wrong_type"],
+            ["repositories[1]"],
+        )
+
+    def test_repository_path_missing(self):
+        self._assert_fails(
+            _mut(lambda d: d["repositories"].__setitem__(0, {"role": "web"})),
+            ["missing_field"],
+            ["repositories[0].path"],
+        )
+
+    def test_repository_dot_rejected(self):
+        # A child repository must be a proper subdirectory of the workspace.
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][0].__setitem__("path", ".")),
+            ["repo_path_not_child"],
+        )
+
+    def test_duplicate_repositories_after_normalization(self):
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][1].__setitem__("path", "./frontend/")),
+            ["duplicate_repository"],
+        )
+
+    def test_repository_docs_traversal(self):
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][0].__setitem__("docs", "../x")),
+            ["path_traversal"],
+            ["repositories[0].docs"],
+        )
+
+    def test_repository_role_wrong_type(self):
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][0].__setitem__("role", 3)),
+            ["wrong_type"],
+            ["repositories[0].role"],
+        )
+
+    def test_errors_are_collected_not_fail_fast(self):
+        data = _mut(lambda d: d["memory"].__setitem__("personal_root", "/abs"))
+        data["memory"]["promotion_mode"] = "auto"
+        data["repositories"][0]["path"] = "../up"
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        got = _codes(errors)
+        for code in ("absolute_path", "invalid_promotion_mode", "path_traversal"):
+            self.assertIn(code, got)
+
+    def test_error_objects_carry_message(self):
+        _, errors = wm.validate_manifest({"version": 2, "workspace_name": "w"})
+        self.assertTrue(all(e.message for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_workspace_manifest.py
+++ b/tests/python/test_workspace_manifest.py
@@ -8,10 +8,19 @@ fail-closed (any error => no manifest), schema defaults, containment +
 disjointness + the v1 operational_root pin, unknown keys preserved. No
 filesystem access — git-worktree existence and symlink canonicalization
 belong to detection/status (issues 2-3), not this layer.
+
+Pass-2 hardening (PR #32 codex review): the validator must be TOTAL — hostile
+input (cycles, depth, huge ints, NUL/surrogate paths, non-UTF-8 CLI files)
+yields typed fail-closed errors, never an exception — and the error oracle
+here asserts EXACT code sets, not inclusion, so extra or missing errors fail.
 """
 
+import contextlib
+import io
 import json
+import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -23,10 +32,6 @@ import workspace_manifest as wm  # type: ignore[reportMissingImports]  # noqa: E
 
 def _codes(errors):
     return sorted({e.code for e in errors})
-
-
-def _fields(errors):
-    return sorted({e.field for e in errors})
 
 
 MINIMAL = {"version": 1, "workspace_name": "w"}
@@ -117,10 +122,14 @@ class SuccessCases(unittest.TestCase):
         _, errors = wm.validate_manifest(data)
         self.assertEqual(errors, [])
 
+    def test_dotdot_lookalike_segments_are_legal(self):
+        # "..." and "..hidden" are ordinary names, not traversal.
+        data = _valid_full()
+        data["repositories"][0]["path"] = "...archive/..hidden"
+        _, errors = wm.validate_manifest(data)
+        self.assertEqual(errors, [])
 
-# Table of error cases: (name, mutate(data) -> data or raw text, expected codes,
-# optionally expected field substrings). Every case must fail CLOSED: no
-# manifest object alongside errors.
+
 def _mut(fn):
     data = _valid_full()
     fn(data)
@@ -128,6 +137,12 @@ def _mut(fn):
 
 
 class ErrorTable(unittest.TestCase):
+    """Exact-set oracle: expected_codes is the COMPLETE set of distinct codes.
+
+    Inclusion-only oracles let extra errors and suppressed errors pass — the
+    pass-2 review proved it by hiding a collected-errors defect behind one.
+    """
+
     def _assert_fails(self, data_or_text, expected_codes, expected_fields=()):
         if isinstance(data_or_text, str):
             manifest, errors = wm.parse_manifest_text(data_or_text)
@@ -135,12 +150,14 @@ class ErrorTable(unittest.TestCase):
             manifest, errors = wm.validate_manifest(data_or_text)
         self.assertIsNone(manifest, "fail-closed: errors must mean no manifest")
         self.assertTrue(errors, "expected at least one error")
-        for code in expected_codes:
-            self.assertIn(code, _codes(errors), f"missing code {code}: {errors}")
+        self.assertEqual(
+            _codes(errors), sorted(set(expected_codes)),
+            f"exact code-set mismatch: {errors}",
+        )
         for field in expected_fields:
             self.assertTrue(
                 any(field in e.field for e in errors),
-                f"no error on field containing '{field}': {_fields(errors)}",
+                f"no error on field containing '{field}': {errors}",
             )
 
     def test_invalid_json(self):
@@ -170,13 +187,18 @@ class ErrorTable(unittest.TestCase):
             ["version"],
         )
 
+    def test_both_required_fields_absent(self):
+        _, errors = wm.validate_manifest({})
+        self.assertEqual(_codes(errors), ["missing_field"])
+        self.assertEqual(
+            sorted(e.field for e in errors), ["version", "workspace_name"]
+        )
+
     def test_workspace_name_missing(self):
         self._assert_fails({"version": 1}, ["missing_field"], ["workspace_name"])
 
-    def test_workspace_name_empty(self):
-        self._assert_fails(
-            {"version": 1, "workspace_name": "  "}, ["empty_value"]
-        )
+    def test_workspace_name_blank(self):
+        self._assert_fails({"version": 1, "workspace_name": "  "}, ["empty_value"])
 
     def test_workspace_name_wrong_type(self):
         self._assert_fails({"version": 1, "workspace_name": 42}, ["wrong_type"])
@@ -189,7 +211,6 @@ class ErrorTable(unittest.TestCase):
         )
 
     def test_operational_root_reserved_pin(self):
-        # The proposal's own example of a v1-reserved value.
         self._assert_fails(
             _mut(lambda d: d["memory"].__setitem__("operational_root", "ops/memory")),
             ["operational_root_reserved"],
@@ -197,8 +218,6 @@ class ErrorTable(unittest.TestCase):
         )
 
     def test_personal_root_nested_in_operational(self):
-        # Proposal disjointness example: would let `git add Memory/` stage
-        # private files.
         self._assert_fails(
             _mut(lambda d: d["memory"].__setitem__("personal_root", "Memory/private")),
             ["roots_not_disjoint"],
@@ -215,11 +234,13 @@ class ErrorTable(unittest.TestCase):
         )
 
     def test_operational_outside_shared_git_root(self):
-        # Codex pass-1 scenario on PR #28: write root outside the commit repo.
-        self._assert_fails(
-            _mut(lambda d: d["memory"].__setitem__("shared_git_root", "shared")),
-            ["containment_violation"],
-        )
+        data = _mut(lambda d: d["memory"].__setitem__("shared_git_root", "shared"))
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["containment_violation"])
+        # The relation involves two fields; blaming the pinned-correct
+        # operational_root would misdirect repair (pass-2 nit).
+        self.assertEqual(errors[0].field, "memory")
 
     def test_absolute_path_rejected(self):
         self._assert_fails(
@@ -235,11 +256,19 @@ class ErrorTable(unittest.TestCase):
         )
 
     def test_interior_traversal_rejected(self):
-        # Normalization must not launder interior dot-dot segments.
         self._assert_fails(
             _mut(lambda d: d["repositories"][0].__setitem__("path", "a/../../b")),
             ["path_traversal"],
             ["repositories[0].path"],
+        )
+
+    def test_any_dotdot_segment_rejected_even_if_contained(self):
+        # "a/../b" stays lexically inside the root; the validator still
+        # refuses — normalization must never launder dot-dot (documented
+        # strict-side choice).
+        self._assert_fails(
+            _mut(lambda d: d["repositories"][0].__setitem__("path", "a/../b")),
+            ["path_traversal"],
         )
 
     def test_dot_rejected_for_memory_roots(self):
@@ -254,9 +283,33 @@ class ErrorTable(unittest.TestCase):
             ["invalid_path"],
         )
 
-    def test_windows_drive_path_rejected(self):
+    def test_windows_drive_slash_rejected(self):
         self._assert_fails(
             _mut(lambda d: d["memory"].__setitem__("personal_root", "C:/mem")),
+            ["absolute_path"],
+        )
+
+    def test_windows_drive_backslash_rejected(self):
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", "C:\\mem")),
+            ["absolute_path"],
+        )
+
+    def test_windows_drive_relative_rejected(self):
+        # C:relative resolves against the drive's CWD on Windows — never
+        # workspace-relative (pass-2 finding: it previously passed).
+        self._assert_fails(
+            _mut(lambda d: d["memory"].__setitem__("personal_root", "C:mem")),
+            ["absolute_path"],
+        )
+
+    def test_unc_path_rejected(self):
+        self._assert_fails(
+            _mut(
+                lambda d: d["memory"].__setitem__(
+                    "personal_root", "\\\\server\\share"
+                )
+            ),
             ["absolute_path"],
         )
 
@@ -287,8 +340,19 @@ class ErrorTable(unittest.TestCase):
             ["repositories[0].path"],
         )
 
+    def test_repository_missing_path_still_collects_other_errors(self):
+        # Pass-2 BLOCKING: an early `continue` used to suppress these.
+        self._assert_fails(
+            _mut(
+                lambda d: d["repositories"].__setitem__(
+                    0, {"role": 3, "docs": "../x"}
+                )
+            ),
+            ["missing_field", "wrong_type", "path_traversal"],
+            ["repositories[0].path", "repositories[0].role", "repositories[0].docs"],
+        )
+
     def test_repository_dot_rejected(self):
-        # A child repository must be a proper subdirectory of the workspace.
         self._assert_fails(
             _mut(lambda d: d["repositories"][0].__setitem__("path", ".")),
             ["repo_path_not_child"],
@@ -320,13 +384,157 @@ class ErrorTable(unittest.TestCase):
         data["repositories"][0]["path"] = "../up"
         manifest, errors = wm.validate_manifest(data)
         self.assertIsNone(manifest)
-        got = _codes(errors)
-        for code in ("absolute_path", "invalid_promotion_mode", "path_traversal"):
-            self.assertIn(code, got)
+        self.assertEqual(
+            _codes(errors),
+            ["absolute_path", "invalid_promotion_mode", "path_traversal"],
+        )
 
     def test_error_objects_carry_message(self):
         _, errors = wm.validate_manifest({"version": 2, "workspace_name": "w"})
         self.assertTrue(all(e.message for e in errors))
+
+
+class HostilePathCases(unittest.TestCase):
+    """Pass-2 BLOCKING: paths the runtime cannot even stat must fail HERE,
+    inside the typed-error boundary, not later in canonicalization or git."""
+
+    def _root_fails(self, value, code):
+        data = _mut(lambda d: d["memory"].__setitem__("personal_root", value))
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), [code], f"for path {value!r}")
+
+    def test_embedded_nul_rejected(self):
+        self._root_fails("a\x00b", "invalid_path")
+
+    def test_newline_rejected(self):
+        self._root_fails("a\nb", "invalid_path")
+
+    def test_tab_rejected(self):
+        self._root_fails("a\tb", "invalid_path")
+
+    def test_lone_surrogate_rejected(self):
+        self._root_fails("\ud800", "invalid_path")
+
+    def test_del_control_char_rejected(self):
+        self._root_fails("a\x7fb", "invalid_path")
+
+
+class TotalityCases(unittest.TestCase):
+    """Pass-2 BLOCKING: the validator is total — hostile structure yields a
+    typed fail-closed error, never an exception, never a bogus success."""
+
+    def test_deeply_nested_unknown_value_fails_typed(self):
+        deep = current = {}
+        for _ in range(4000):
+            nxt = {}
+            current["k"] = nxt
+            current = nxt
+        data = {"version": 1, "workspace_name": "w", "x_deep": deep}
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["unprocessable"])
+
+    def test_deeply_nested_json_text_fails_typed(self):
+        # Whether the C json parser or the representability probe trips first
+        # is a platform recursion-ceiling detail; the pinned contract is a
+        # typed fail-closed verdict with no exception either way.
+        text = (
+            '{"version": 1, "workspace_name": "w", "x_deep": '
+            + "[" * 4000 + "]" * 4000 + "}"
+        )
+        manifest, errors = wm.parse_manifest_text(text)
+        self.assertIsNone(manifest)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(errors[0].code, ("invalid_json", "unprocessable"))
+
+    def test_huge_integer_json_fails_typed(self):
+        text = (
+            '{"version": 1, "workspace_name": "w", "x_big": '
+            + "9" * 5000 + "}"
+        )
+        manifest, errors = wm.parse_manifest_text(text)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["invalid_json"])
+
+    def test_circular_input_fails_typed(self):
+        data = {"version": 1, "workspace_name": "w"}
+        data["x_cycle"] = data
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["unprocessable"])
+
+    def test_non_json_value_fails_typed(self):
+        data = {"version": 1, "workspace_name": "w", "x_set": {1, 2}}
+        manifest, errors = wm.validate_manifest(data)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["unprocessable"])
+
+    def test_nan_and_infinity_rejected(self):
+        for constant in ("NaN", "Infinity", "-Infinity"):
+            text = (
+                '{"version": 1, "workspace_name": "w", "x_c": ' + constant + "}"
+            )
+            manifest, errors = wm.parse_manifest_text(text)
+            self.assertIsNone(manifest, constant)
+            self.assertEqual(_codes(errors), ["invalid_json"], constant)
+
+    def test_none_input_fails_typed(self):
+        manifest, errors = wm.validate_manifest(None)
+        self.assertIsNone(manifest)
+        self.assertEqual(_codes(errors), ["not_object"])
+
+
+class CliCases(unittest.TestCase):
+    """The shipped CLI surface: JSON verdict + exit code, never a traceback."""
+
+    def _run(self, argv):
+        out = io.StringIO()
+        err = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = wm.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def _tmpfile(self, payload: bytes) -> str:
+        fd, path = tempfile.mkstemp(prefix="asha_wm_", suffix=".json")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(payload)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_valid_file_exits_zero_with_verdict(self):
+        path = self._tmpfile(json.dumps(_valid_full()).encode("utf-8"))
+        rc, out, _ = self._run(["workspace_manifest.py", path])
+        self.assertEqual(rc, 0)
+        verdict = json.loads(out)
+        self.assertTrue(verdict["ok"])
+        self.assertEqual(verdict["errors"], [])
+
+    def test_invalid_manifest_exits_one_with_typed_errors(self):
+        path = self._tmpfile(b'{"version": 2, "workspace_name": "w"}')
+        rc, out, _ = self._run(["workspace_manifest.py", path])
+        self.assertEqual(rc, 1)
+        verdict = json.loads(out)
+        self.assertFalse(verdict["ok"])
+        self.assertEqual(verdict["errors"][0]["code"], "unsupported_version")
+
+    def test_non_utf8_file_yields_typed_error_not_traceback(self):
+        path = self._tmpfile(b"\xff\xfe\x00garbage")
+        rc, out, _ = self._run(["workspace_manifest.py", path])
+        self.assertEqual(rc, 1)
+        verdict = json.loads(out)
+        self.assertFalse(verdict["ok"])
+        self.assertEqual(verdict["errors"][0]["code"], "unreadable")
+
+    def test_missing_file_exits_one(self):
+        rc, out, _ = self._run(["workspace_manifest.py", "/nonexistent/x.json"])
+        self.assertEqual(rc, 1)
+        self.assertFalse(json.loads(out)["ok"])
+
+    def test_bad_argv_exits_two(self):
+        rc, _, err = self._run(["workspace_manifest.py"])
+        self.assertEqual(rc, 2)
+        self.assertIn("usage", err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #31. Head of the workspace v1 dependency chain per the ratified proposal (`docs/proposals/2026-08-06--workspace-memory.md`, delivery item 1) — issues 2–4 consume this validator.

## What changed

- **`plugins/session/tools/workspace_manifest.py`** (new) — pure lexical parse/validate for `.asha/workspace.json`:
  - typed, **collected** errors (stable code + field + message); **fail-closed** — any error means no manifest object
  - schema defaults (`Memory` / `memory-local` / `knowledge` / `.` / `pull-request`); `promotion_mode` enum; `version` must be int 1 (bool rejected; newer versions fail closed)
  - lexical path rules: workspace-relative only; absolute paths, Windows drive forms, backslashes, and any `..` (including interior `a/../../b`) reject; `.` legal only for `shared_git_root`
  - **containment** (`operational_root` inside `shared_git_root`), **disjointness** (three plane roots pairwise non-nesting — `personal_root: Memory/private` fails), and the **v1 pin** (`operational_root == Memory`)
  - repositories: required `path`, optional `role`/`docs`, duplicates and `.` reject
  - unknown keys preserved at every level; input dict never mutated; small CLI verdict mode for later shell integration
- **`tests/python/test_workspace_manifest.py`** (new) — 38 table-driven cases including every proposal-named scenario
- Session plugin **1.13.0 → 1.14.0**; tables + histories synced

## Deliberately out of scope (lands with issues 2–3)

Filesystem checks: git-worktree existence, symlink canonicalization, real-root resolution. This layer is decidable from manifest text alone, which is what keeps it a pure function with exhaustive tests.

## TDD evidence

Test file written first, confirmed RED (module absent), then GREEN — 38/38. Full suite `./tests/run-tests.sh`: **13/13**.

Pass-2 Codex adversarial review to follow on this PR before it leaves draft, per house rule (9/9 fix batches with confirmed defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)