### PR TITLE
feat: project-root consolidation + workspace walk (workspace v1, delivery issue 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This guide helps AI assistants (like Claude) understand the asha codebase struct
 
 | Plugin | Version | Domain | Description |
 |--------|---------|--------|-------------|
-| **Session** | v1.14.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Session** | v1.15.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Asha** | v2.1.0 | Identity | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Panel System** | v5.0.0 | Research | Multi-perspective analysis with persistence and resumption — 6 agents |
 | **Code** | v1.5.0 | Development | Code review, orchestration patterns, TDD, issue-to-merge loop — 5 agents, postgres skill |
@@ -919,6 +919,15 @@ git push -u origin <branch-name>
 ---
 
 ## Version History
+
+### Session v1.15.0 (2026-08-07) — project-root consolidation + workspace walk
+
+Workspace v1 delivery issue 2 (issue #33). Six divergent detection copies →
+one resolver per language (`tools/project-root.sh`, `tools/project_root.py`),
+callers declare historical layer sets, byte-identical per Test 9b pins +
+existing Python suites. New unconsumed `detect_workspace()` primitive
+($HOME and / exclusive, canonical comparison, typed verdict on invalid
+manifests). Exempt-by-design detection sites catalogued in the PR audit.
 
 ### Session v1.14.0 (2026-08-07) — workspace manifest validator
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ They form a pipeline, not an overlap: guardrails read session_state for in-fligh
 
 | Domain | Plugin | Version | Purpose |
 |--------|--------|---------|---------|
-| **Core** | `session` | v1.14.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Core** | `session` | v1.15.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Identity** | `asha` | v2.1.0 | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Research** | `panel-system` | v5.0.0 | Multi-perspective analysis, expert panels, decision-making — 6 agents |
 | **Development** | `code` | v1.5.0 | Code review, orchestration patterns, TDD, overnight issue-to-merge loop — 5 agents |
@@ -335,7 +335,7 @@ Create a ComfyUI workflow for: txt2img with upscaling
 
 **Plugin Name**: `session`
 **Commands**: `/session:init`, `/session:save`, `/session:status`, `/session:silence`, `/session:restore`, `/session:loop`
-**Version**: 1.14.0
+**Version**: 1.15.0
 **Domain**: Core
 
 Session coordination and memory persistence — the foundation layer other plugins build on. Learnings persist as an OKF concept bundle (`~/.asha/learnings/`, one file per learning) with auto-suggested `## Related` cross-links at `/save`; see [`docs/memory-architecture.md`](docs/memory-architecture.md).
@@ -563,6 +563,24 @@ Individual plugins licensed separately. See each plugin's LICENSE file (MIT thro
 ---
 
 ## Version History
+
+### Session v1.15.0 — project-root consolidation + workspace walk (2026-08-07)
+
+Workspace v1 delivery issue 2 (issue #33). The layered Memory-root detection
+algorithm previously existed in **six divergent copies** (three bash, three
+Python — no two byte-identical, five distinct layer orders); workspace
+detection added to one would not have propagated. It now exists exactly once
+per language: `tools/project-root.sh` and `tools/project_root.py`, with each
+historical caller declaring its exact layer set, so per-consumer behavior is
+byte-identical — pinned by the new Test 9b (12 detector-semantics pins,
+green before AND after the rewire) and the existing Python suites. New
+`detect_workspace()` primitive walks upward for `.asha/workspace.json`
+(stopping exclusively before `$HOME` and `/`, canonical comparison, invalid
+manifest = typed verdict, never silent fallthrough) — deliberately consumed
+by NOTHING yet; issues 3–4 wire it. Audit: no independent layered fallback
+chain remains; exempt-by-design sites (build-root detector in verify.py,
+issue-loop's git-only refuse, thin command-MD one-liners, payload-cwd
+hooks) are catalogued in PR #34.
 
 ### Session v1.14.0 — workspace manifest validator (2026-08-07)
 

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -1,6 +1,6 @@
 # Session
 
-**Version**: 1.14.0
+**Version**: 1.15.0
 
 Session management with memory persistence, pattern extraction, and operational quality.
 

--- a/plugins/session/hooks/handlers/common.sh
+++ b/plugins/session/hooks/handlers/common.sh
@@ -2,8 +2,14 @@
 # Common utilities for Asha hooks (plugin version)
 # Source this file in hooks: source "$(dirname "$0")/common.sh"
 
-# Shared project-root resolver (single source of truth for root detection)
-source "$(dirname "${BASH_SOURCE[0]}")/../../tools/project-root.sh"
+# Shared project-root resolver (single source of truth for root detection).
+# Parameter expansion, not `dirname`: a hook must not acquire a dependency on
+# an external binary before it can even resolve a project (a stripped PATH
+# previously degraded to "no project"; it must not become exit 127). Sourced
+# defensively so a partial install degrades instead of erroring.
+if [[ -f "${BASH_SOURCE[0]%/*}/../../tools/project-root.sh" ]]; then
+    source "${BASH_SOURCE[0]%/*}/../../tools/project-root.sh"
+fi
 
 # Detect project directory
 # Returns project directory path on stdout, or empty string if not found
@@ -11,6 +17,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../tools/project-root.sh"
 # Hook detector layer set: env verbatim, else git-with-Memory; NO upward
 # walk; $HOME guard. Semantics pinned by Test 9/9b — do not widen here.
 detect_project_dir() {
+    # Fail-open on a partial install: hooks must never hard-error.
+    if ! declare -F asha_detect_project_root >/dev/null 2>&1; then
+        echo ""
+        return 0
+    fi
     asha_detect_project_root "env,git" 1
 }
 

--- a/plugins/session/hooks/handlers/common.sh
+++ b/plugins/session/hooks/handlers/common.sh
@@ -2,33 +2,16 @@
 # Common utilities for Asha hooks (plugin version)
 # Source this file in hooks: source "$(dirname "$0")/common.sh"
 
+# Shared project-root resolver (single source of truth for root detection)
+source "$(dirname "${BASH_SOURCE[0]}")/../../tools/project-root.sh"
+
 # Detect project directory
 # Returns project directory path on stdout, or empty string if not found
 # Always returns 0 (safe under set -e)
+# Hook detector layer set: env verbatim, else git-with-Memory; NO upward
+# walk; $HOME guard. Semantics pinned by Test 9/9b — do not widen here.
 detect_project_dir() {
-    local dir=""
-
-    # Use CLAUDE_PROJECT_DIR if set (Claude Code hook invocation)
-    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-        dir="$CLAUDE_PROJECT_DIR"
-    # Fallback: Try git root
-    elif command -v git >/dev/null 2>&1; then
-        local git_root
-        git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-        if [[ -n "$git_root" ]] && [[ -d "$git_root/Memory" ]]; then
-            dir="$git_root"
-        fi
-    fi
-
-    # $HOME is the identity layer (~/.asha), never a project — home-cwd
-    # sessions and one-shot invocations must not grow Memory/ or Work/ at ~
-    if [[ -n "$dir" ]] && [[ "$(readlink -f "$dir")" == "$(readlink -f "$HOME")" ]]; then
-        dir=""
-    fi
-
-    # Empty string (not error) when no project detected
-    echo "$dir"
-    return 0
+    asha_detect_project_root "env,git" 1
 }
 
 # Get plugin root directory (where asha plugin is installed)

--- a/plugins/session/tools/event_store.py
+++ b/plugins/session/tools/event_store.py
@@ -13,14 +13,12 @@ Usage:
     python event_store.py stats
 """
 
-import os
 import sys
 import re
 import json
 import uuid
 import fcntl
 import argparse
-import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
 from typing import Any, Optional, Dict, List
@@ -102,34 +100,18 @@ def scrub_payload(payload: Any) -> Any:
 
 
 def detect_project_root() -> Path:
-    """Find project root via environment, git, or upward search for Memory/"""
-    # Layer 1: Use CLAUDE_PROJECT_DIR if set (hook invocation)
-    claude_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if claude_project_dir:
-        project_path = Path(claude_project_dir)
-        if (project_path / "Memory").is_dir():
-            return project_path
+    """Find project root via environment, git, or upward search for Memory/
 
-    # Layer 2: Try git root
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True
-        )
-        git_root = Path(result.stdout.strip())
-        if (git_root / "Memory").is_dir():
-            return git_root
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
-
-    # Layer 3: Upward search for Memory/ directory
-    search_dir = Path(__file__).parent.resolve()
-    while search_dir != search_dir.parent:
-        if (search_dir / "Memory").is_dir():
-            return search_dir
-        search_dir = search_dir.parent
-
-    raise RuntimeError("Cannot detect project root. Ensure Memory/ directory exists.")
+    Delegates to the shared resolver (project_root.py) with this module's
+    historical layer set: validated env, git-with-Memory, upward walk from
+    the tools dir, RuntimeError on failure. No argv layer — this module is
+    bound at import time with no CLI escape hatch (historical).
+    """
+    from project_root import detect_project_root as _shared_detect
+    return _shared_detect(
+        walk_base=Path(__file__).parent.resolve(),
+        on_fail="raise",
+    )
 
 
 # Project paths (detected dynamically)

--- a/plugins/session/tools/event_store.py
+++ b/plugins/session/tools/event_store.py
@@ -107,6 +107,9 @@ def detect_project_root() -> Path:
     the tools dir, RuntimeError on failure. No argv layer — this module is
     bound at import time with no CLI escape hatch (historical).
     """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:  # importlib/embedded loaders
+        sys.path.insert(0, tools_dir)
     from project_root import detect_project_root as _shared_detect
     return _shared_detect(
         walk_base=Path(__file__).parent.resolve(),

--- a/plugins/session/tools/learnings_manager.py
+++ b/plugins/session/tools/learnings_manager.py
@@ -55,6 +55,9 @@ def _detect_project_root_for_silence() -> Optional[Path]:
     detector's historical base). Returns None if no root can be found —
     callers fail-open (allow the write) rather than block on missing context.
     """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:  # importlib/embedded loaders
+        sys.path.insert(0, tools_dir)
     from project_root import detect_project_root as _shared_detect
     return _shared_detect(walk_base=Path.cwd(), on_fail="none")
 

--- a/plugins/session/tools/learnings_manager.py
+++ b/plugins/session/tools/learnings_manager.py
@@ -50,35 +50,13 @@ except ImportError:  # pragma: no cover - fallback path exercised only without P
 def _detect_project_root_for_silence() -> Optional[Path]:
     """Best-effort project root detection for silence-marker check.
 
-    Mirrors pattern_analyzer.detect_project_root semantics: env var first,
-    then git rev-parse, then upward search from CWD. Returns None if no root
-    can be found — callers should fail-open (allow the write) in that case
-    rather than block on missing context.
+    Delegates to the shared resolver (project_root.py): validated env, git
+    with Memory/, upward walk from CWD (note: cwd, not the tools dir — this
+    detector's historical base). Returns None if no root can be found —
+    callers fail-open (allow the write) rather than block on missing context.
     """
-    claude_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if claude_project_dir:
-        candidate = Path(claude_project_dir)
-        if (candidate / "Memory").is_dir():
-            return candidate
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True
-        )
-        git_root = Path(result.stdout.strip())
-        if (git_root / "Memory").is_dir():
-            return git_root
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
-
-    search_dir = Path.cwd()
-    while search_dir != search_dir.parent:
-        if (search_dir / "Memory").is_dir():
-            return search_dir
-        search_dir = search_dir.parent
-
-    return None
+    from project_root import detect_project_root as _shared_detect
+    return _shared_detect(walk_base=Path.cwd(), on_fail="none")
 
 
 def _silence_marker_present() -> bool:

--- a/plugins/session/tools/pattern_analyzer.py
+++ b/plugins/session/tools/pattern_analyzer.py
@@ -18,7 +18,6 @@ import json
 import fcntl
 import hashlib
 import argparse
-import subprocess
 import tempfile
 import stat
 from contextlib import contextmanager
@@ -30,42 +29,18 @@ from collections import defaultdict, Counter
 
 
 def detect_project_root() -> Path:
-    """Find project root, honoring the CLI's explicit directory before cwd."""
-    for index, argument in enumerate(sys.argv[1:]):
-        explicit = None
-        if argument in {"--project-dir", "-p"} and index + 2 <= len(sys.argv[1:]):
-            explicit = sys.argv[1:][index + 1]
-        elif argument.startswith("--project-dir="):
-            explicit = argument.split("=", 1)[1]
-        if explicit:
-            project_path = Path(explicit).resolve()
-            if (project_path / "Memory").is_dir():
-                return project_path
+    """Find project root, honoring the CLI's explicit directory before cwd.
 
-    claude_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if claude_project_dir:
-        project_path = Path(claude_project_dir)
-        if (project_path / "Memory").is_dir():
-            return project_path
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True
-        )
-        git_root = Path(result.stdout.strip())
-        if (git_root / "Memory").is_dir():
-            return git_root
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
-
-    search_dir = Path(__file__).parent.resolve()
-    while search_dir != search_dir.parent:
-        if (search_dir / "Memory").is_dir():
-            return search_dir
-        search_dir = search_dir.parent
-
-    raise RuntimeError("Cannot detect project root. Ensure Memory/ directory exists.")
+    Delegates to the shared resolver (project_root.py) with this module's
+    historical layer set: argv scan, validated env, git-with-Memory, upward
+    walk from the tools dir, RuntimeError on failure.
+    """
+    from project_root import detect_project_root as _shared_detect
+    return _shared_detect(
+        argv=sys.argv[1:],
+        walk_base=Path(__file__).parent.resolve(),
+        on_fail="raise",
+    )
 
 
 # Paths

--- a/plugins/session/tools/pattern_analyzer.py
+++ b/plugins/session/tools/pattern_analyzer.py
@@ -35,6 +35,9 @@ def detect_project_root() -> Path:
     historical layer set: argv scan, validated env, git-with-Memory, upward
     walk from the tools dir, RuntimeError on failure.
     """
+    tools_dir = str(Path(__file__).resolve().parent)
+    if tools_dir not in sys.path:  # importlib/embedded loaders
+        sys.path.insert(0, tools_dir)
     from project_root import detect_project_root as _shared_detect
     return _shared_detect(
         argv=sys.argv[1:],

--- a/plugins/session/tools/project-root.sh
+++ b/plugins/session/tools/project-root.sh
@@ -34,7 +34,11 @@ asha_detect_project_root() {
     elif [[ ",$layers," == *",env,"* && -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
         dir="$CLAUDE_PROJECT_DIR"
     else
-        if [[ -z "$dir" && ",$layers," == *",git,"* ]]; then
+        # `command -v git` guard is load-bearing, not decoration: without it a
+        # shell carrying a command_not_found_handle can fabricate stdout that
+        # would be accepted as a project root.
+        if [[ -z "$dir" && ",$layers," == *",git,"* ]] \
+            && command -v git >/dev/null 2>&1; then
             local git_root
             git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
             if [[ -n "$git_root" && -d "$git_root/Memory" ]]; then
@@ -55,6 +59,7 @@ asha_detect_project_root() {
     fi
 
     if [[ "$home_guard" == "1" && -n "$dir" ]] \
+        && command -v readlink >/dev/null 2>&1 \
         && [[ "$(readlink -f "$dir")" == "$(readlink -f "$HOME")" ]]; then
         dir=""
     fi

--- a/plugins/session/tools/project-root.sh
+++ b/plugins/session/tools/project-root.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# project-root.sh — the ONE project-root resolver (workspace v1, issue #33).
+# source-scoped library: no set flags at file scope (runs in the caller's shell)
+#
+# Before this file existed, the layered Memory-root algorithm lived in three
+# divergent bash copies (hooks/handlers/common.sh, tools/save-session.sh,
+# tools/save-preflight-env.sh) — no two byte-identical. Workspace detection
+# added to one copy would not have propagated. Each caller now declares its
+# HISTORICAL layer set, so per-consumer behavior stays byte-identical
+# (pinned by tests/test-hooks.sh Test 9b) while the algorithm exists exactly
+# once. Do not add a new independent fallback chain anywhere — extend this.
+#
+# asha_detect_project_root LAYERS HOME_GUARD [EXPLICIT]
+#   LAYERS      comma-joined subset of: env,git,walk
+#     env   CLAUDE_PROJECT_DIR taken VERBATIM if set — unvalidated, and it
+#           STOPS the chain even when the dir lacks Memory/ (every historical
+#           detector behaved this way; harnesses that set it are trusted)
+#     git   `git rev-parse --show-toplevel` accepted iff it contains Memory/
+#     walk  upward from $PWD for a directory containing Memory/
+#   HOME_GUARD  1 = a result that canonicalizes to $HOME is discarded ($HOME
+#               is the identity layer, never a project)
+#   EXPLICIT    optional explicit dir (a caller's --project-dir layer); taken
+#               verbatim when non-empty, before every other layer
+#
+# stdout: resolved dir, or empty when nothing (acceptable) resolved.
+# rc: always 0 — failure POLICY (exit, error text, fallthrough) is the
+#     caller's, and the historical callers differ on it deliberately.
+asha_detect_project_root() {
+    local layers="$1" home_guard="$2" explicit="${3:-}"
+    local dir=""
+
+    if [[ -n "$explicit" ]]; then
+        dir="$explicit"
+    elif [[ ",$layers," == *",env,"* && -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+        dir="$CLAUDE_PROJECT_DIR"
+    else
+        if [[ -z "$dir" && ",$layers," == *",git,"* ]]; then
+            local git_root
+            git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+            if [[ -n "$git_root" && -d "$git_root/Memory" ]]; then
+                dir="$git_root"
+            fi
+        fi
+        if [[ -z "$dir" && ",$layers," == *",walk,"* ]]; then
+            local search
+            search="$(pwd)"
+            while [[ "$search" != "/" ]]; do
+                if [[ -d "$search/Memory" ]]; then
+                    dir="$search"
+                    break
+                fi
+                search="$(dirname "$search")"
+            done
+        fi
+    fi
+
+    if [[ "$home_guard" == "1" && -n "$dir" ]] \
+        && [[ "$(readlink -f "$dir")" == "$(readlink -f "$HOME")" ]]; then
+        dir=""
+    fi
+
+    echo "$dir"
+    return 0
+}

--- a/plugins/session/tools/project_root.py
+++ b/plugins/session/tools/project_root.py
@@ -29,7 +29,12 @@ import sys
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 
-import workspace_manifest
+# Sibling import must work even when tools/ is not already on sys.path (an
+# importlib/embedded loader, or a caller importing this by file path).
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import workspace_manifest  # noqa: E402
 
 
 class WorkspaceDetection(NamedTuple):
@@ -109,19 +114,43 @@ def detect_project_root(
     return None
 
 
+def _err(code: str, message: str) -> "workspace_manifest.ManifestError":
+    return workspace_manifest.ManifestError(code, "", message)
+
+
 def detect_workspace(start: Optional[Path] = None) -> WorkspaceDetection:
     """Walk upward for .asha/workspace.json; $HOME and / are never roots.
+
+    TOTAL: every filesystem failure becomes a typed verdict. A consumer must
+    be able to distinguish "no workspace" from "detection could not run" —
+    a traceback escaping here would crash a session hook.
 
     Returns:
       (None, None, [])       — no workspace (the overwhelmingly common case)
       (root, manifest, [])   — valid workspace
-      (root, None, errors)   — manifest found but invalid/unreadable: a typed
-                               fail-closed verdict. The walk STOPS at the
-                               first manifest — climbing past a broken one to
-                               a higher workspace would silently mask it.
+      (root, None, errors)   — manifest found but invalid/unreadable/not a
+                               regular file: a typed fail-closed verdict. The
+                               walk STOPS at the first manifest PATH THAT
+                               EXISTS — climbing past a broken one to a higher
+                               workspace would silently mask it.
+      (None, None, errors)   — detection itself failed (bad start, unreadable
+                               ancestor, symlink loop)
     """
-    candidate = Path(start if start is not None else Path.cwd()).resolve()
-    home = Path(os.environ.get("HOME", str(Path.home()))).resolve()
+    try:
+        raw = Path(start if start is not None else Path.cwd())
+        candidate = raw.resolve()
+        if not candidate.is_dir():
+            return WorkspaceDetection(None, None, [
+                _err("invalid_start",
+                     f"start path is not an existing directory: {raw}")
+            ])
+        home = Path(os.environ.get("HOME") or str(Path.home())).resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        # RuntimeError: symlink loop during resolve(); OSError: unreadable
+        # ancestor; ValueError: embedded NUL and friends.
+        return WorkspaceDetection(None, None, [
+            _err("invalid_start", f"cannot resolve start path: {exc}")
+        ])
 
     while True:
         # Both bounds exclusive: the user-scope config dir (~/.asha) must
@@ -131,15 +160,31 @@ def detect_workspace(start: Optional[Path] = None) -> WorkspaceDetection:
             return WorkspaceDetection(None, None, [])
 
         manifest_path = candidate / ".asha" / "workspace.json"
-        if manifest_path.is_file():
+        try:
+            # lexists, not is_file: a manifest path that EXISTS but is a
+            # directory, socket, or broken symlink must fail closed here, not
+            # read as "no manifest at this level" and let the walk continue.
+            exists = manifest_path.is_symlink() or manifest_path.exists()
+            is_regular = manifest_path.is_file()
+        except OSError as exc:
+            return WorkspaceDetection(None, None, [
+                _err("walk_failed",
+                     f"cannot inspect {manifest_path}: {exc}")
+            ])
+
+        if exists and not is_regular:
+            return WorkspaceDetection(candidate, None, [
+                _err("not_a_file",
+                     f"workspace manifest path exists but is not a regular "
+                     f"readable file: {manifest_path}")
+            ])
+        if is_regular:
             try:
                 text = manifest_path.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError) as exc:
                 return WorkspaceDetection(candidate, None, [
-                    workspace_manifest.ManifestError(
-                        "unreadable", "",
-                        f"workspace manifest exists but cannot be read: {exc}",
-                    )
+                    _err("unreadable",
+                         f"workspace manifest exists but cannot be read: {exc}")
                 ])
             manifest, errors = workspace_manifest.parse_manifest_text(text)
             return WorkspaceDetection(candidate, manifest, errors)
@@ -159,16 +204,17 @@ def main(argv: List[str]) -> int:
         return 2
     start: Optional[Path] = None
     rest = argv[2:]
-    if rest[:1] == ["--start"] and len(rest) >= 2:
+    if rest[:1] == ["--start"] and len(rest) == 2:
         start = Path(rest[1])
-    elif rest and rest[0].startswith("--start="):
+    elif len(rest) == 1 and rest[0].startswith("--start="):
         start = Path(rest[0].split("=", 1)[1])
     elif rest:
+        # Trailing junk is a usage error, never a silent "no workspace".
         print("usage: project_root.py workspace [--start DIR]", file=sys.stderr)
         return 2
 
     det = detect_workspace(start=start)
-    ok = det.root is None or det.manifest is not None
+    ok = not det.errors and (det.root is None or det.manifest is not None)
     print(json.dumps({
         "workspace_root": str(det.root) if det.root is not None else None,
         "ok": ok,

--- a/plugins/session/tools/project_root.py
+++ b/plugins/session/tools/project_root.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+project_root.py — the ONE Python project-root resolver, plus the workspace
+walk (workspace v1, delivery issue 2 — issue #33).
+
+Before this module existed, the layered Memory-root algorithm lived in three
+divergent Python copies (pattern_analyzer, event_store, learnings_manager) —
+different layer sets, different walk bases, different failure modes. Each
+historical caller now delegates here, declaring its exact historical
+parameters, so behavior stays byte-identical while the algorithm exists
+once. Do not add a new independent fallback chain anywhere — extend this.
+
+Python detectors differ from the bash ones deliberately (and historically):
+the CLAUDE_PROJECT_DIR layer is VALIDATED against Memory/ here, verbatim in
+bash. That divergence is pinned, not fixed.
+
+detect_workspace() is NEW and — in this increment — consumed by nothing:
+it walks upward from a start directory for .asha/workspace.json, stopping
+BEFORE $HOME and BEFORE the filesystem root (both exclusive, canonical
+comparison), and validates a found manifest via workspace_manifest. An
+invalid manifest is a typed verdict, never a silent keep-walking fallback —
+a swallowed manifest error would be indistinguishable from "no workspace".
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+import workspace_manifest
+
+
+class WorkspaceDetection(NamedTuple):
+    root: Optional[Path]
+    manifest: Optional[dict]
+    errors: List["workspace_manifest.ManifestError"]
+
+
+_FAIL_MESSAGE = "Cannot detect project root. Ensure Memory/ directory exists."
+
+
+def _argv_explicit(args: List[str]) -> Optional[Path]:
+    """The historical pattern_analyzer argv scan, preserved verbatim:
+    runs before argparse (import time), validates against Memory/."""
+    for index, argument in enumerate(args):
+        explicit = None
+        if argument in {"--project-dir", "-p"} and index + 2 <= len(args):
+            explicit = args[index + 1]
+        elif argument.startswith("--project-dir="):
+            explicit = argument.split("=", 1)[1]
+        if explicit:
+            project_path = Path(explicit).resolve()
+            if (project_path / "Memory").is_dir():
+                return project_path
+    return None
+
+
+def detect_project_root(
+    *,
+    argv: Optional[List[str]] = None,
+    use_env: bool = True,
+    use_git: bool = True,
+    walk_base: Optional[Path] = None,
+    on_fail: str = "raise",
+) -> Optional[Path]:
+    """Layered Memory-root resolution. Callers declare their historical set.
+
+    argv       list to scan for --project-dir/-p (validated); None = no scan
+    use_env    CLAUDE_PROJECT_DIR, validated against Memory/
+    use_git    `git rev-parse --show-toplevel` accepted iff it contains Memory/
+    walk_base  upward-walk start directory; None = no walk
+    on_fail    "raise" (historical RuntimeError, exact message) or "none"
+    """
+    if argv:
+        found = _argv_explicit(argv)
+        if found is not None:
+            return found
+
+    if use_env:
+        claude_project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+        if claude_project_dir:
+            project_path = Path(claude_project_dir)
+            if (project_path / "Memory").is_dir():
+                return project_path
+
+    if use_git:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, check=True,
+            )
+            git_root = Path(result.stdout.strip())
+            if (git_root / "Memory").is_dir():
+                return git_root
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+    if walk_base is not None:
+        search_dir = Path(walk_base).resolve()
+        while search_dir != search_dir.parent:
+            if (search_dir / "Memory").is_dir():
+                return search_dir
+            search_dir = search_dir.parent
+
+    if on_fail == "raise":
+        raise RuntimeError(_FAIL_MESSAGE)
+    return None
+
+
+def detect_workspace(start: Optional[Path] = None) -> WorkspaceDetection:
+    """Walk upward for .asha/workspace.json; $HOME and / are never roots.
+
+    Returns:
+      (None, None, [])       — no workspace (the overwhelmingly common case)
+      (root, manifest, [])   — valid workspace
+      (root, None, errors)   — manifest found but invalid/unreadable: a typed
+                               fail-closed verdict. The walk STOPS at the
+                               first manifest — climbing past a broken one to
+                               a higher workspace would silently mask it.
+    """
+    candidate = Path(start if start is not None else Path.cwd()).resolve()
+    home = Path(os.environ.get("HOME", str(Path.home()))).resolve()
+
+    while True:
+        # Both bounds exclusive: the user-scope config dir (~/.asha) must
+        # never make $HOME a workspace, and a root-level manifest must never
+        # make the whole machine one.
+        if candidate == home or candidate == candidate.parent:
+            return WorkspaceDetection(None, None, [])
+
+        manifest_path = candidate / ".asha" / "workspace.json"
+        if manifest_path.is_file():
+            try:
+                text = manifest_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                return WorkspaceDetection(candidate, None, [
+                    workspace_manifest.ManifestError(
+                        "unreadable", "",
+                        f"workspace manifest exists but cannot be read: {exc}",
+                    )
+                ])
+            manifest, errors = workspace_manifest.parse_manifest_text(text)
+            return WorkspaceDetection(candidate, manifest, errors)
+
+        candidate = candidate.parent
+
+
+def main(argv: List[str]) -> int:
+    """CLI (consumed by later increments: status verb, save scoping).
+
+    project_root.py workspace [--start DIR]
+      Prints a JSON verdict {workspace_root, ok, errors, manifest}.
+      rc 0 = no workspace or a valid one; rc 1 = manifest found but invalid.
+    """
+    if len(argv) < 2 or argv[1] != "workspace":
+        print("usage: project_root.py workspace [--start DIR]", file=sys.stderr)
+        return 2
+    start: Optional[Path] = None
+    rest = argv[2:]
+    if rest[:1] == ["--start"] and len(rest) >= 2:
+        start = Path(rest[1])
+    elif rest and rest[0].startswith("--start="):
+        start = Path(rest[0].split("=", 1)[1])
+    elif rest:
+        print("usage: project_root.py workspace [--start DIR]", file=sys.stderr)
+        return 2
+
+    det = detect_workspace(start=start)
+    ok = det.root is None or det.manifest is not None
+    print(json.dumps({
+        "workspace_root": str(det.root) if det.root is not None else None,
+        "ok": ok,
+        "errors": [e._asdict() for e in det.errors],
+        "manifest": det.manifest,
+    }, indent=2, sort_keys=True))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/plugins/session/tools/save-preflight-env.sh
+++ b/plugins/session/tools/save-preflight-env.sh
@@ -89,29 +89,15 @@ resolve_asha_root() {
     return 1
 }
 
+# Shared project-root resolver (single source of truth for root detection)
+source "$(dirname "$0")/project-root.sh"
+
+# Full layer set (arg, env, git-with-Memory, upward walk) WITH the $HOME
+# guard — the union detector, pinned by Test 9b. Empty output + rc 1 when
+# nothing resolves; the consumer block exits 2 with remediation.
 resolve_project_dir() {
-    local dir=""
-    if [[ -n "$ARG_PROJECT_DIR" ]]; then
-        dir="$ARG_PROJECT_DIR"
-    elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-        dir="$CLAUDE_PROJECT_DIR"
-    else
-        local git_root
-        git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-        if [[ -n "$git_root" && -d "$git_root/Memory" ]]; then
-            dir="$git_root"
-        else
-            local search="$PWD"
-            while [[ "$search" != "/" ]]; do
-                if [[ -d "$search/Memory" ]]; then dir="$search"; break; fi
-                search="$(dirname "$search")"
-            done
-        fi
-    fi
-    # $HOME is the identity layer, never a project (see detect_project_dir fix)
-    if [[ -n "$dir" && "$(readlink -f "$dir")" == "$(readlink -f "$HOME")" ]]; then
-        dir=""
-    fi
+    local dir
+    dir="$(asha_detect_project_root "env,git,walk" 1 "$ARG_PROJECT_DIR")"
     [[ -n "$dir" ]] && echo "$dir"
 }
 

--- a/plugins/session/tools/save-preflight-env.sh
+++ b/plugins/session/tools/save-preflight-env.sh
@@ -89,14 +89,24 @@ resolve_asha_root() {
     return 1
 }
 
-# Shared project-root resolver (single source of truth for root detection)
-source "$(dirname "$0")/project-root.sh"
+# Shared project-root resolver (single source of truth for root detection).
+# BASH_SOURCE, not $0 (correct when sourced or symlink-invoked); missing file
+# is reported as the documented partial-install failure, not a bare
+# command-not-found from the wrapper below.
+if [[ -f "${BASH_SOURCE[0]%/*}/project-root.sh" ]]; then
+    source "${BASH_SOURCE[0]%/*}/project-root.sh"
+fi
 
 # Full layer set (arg, env, git-with-Memory, upward walk) WITH the $HOME
 # guard — the union detector, pinned by Test 9b. Empty output + rc 1 when
 # nothing resolves; the consumer block exits 2 with remediation.
 resolve_project_dir() {
     local dir
+    if ! declare -F asha_detect_project_root >/dev/null 2>&1; then
+        # Partial install: stay silent here so the PLUGIN phase below reports
+        # the documented exit-3 remediation instead of an env-phase failure.
+        return 0
+    fi
     dir="$(asha_detect_project_root "env,git,walk" 1 "$ARG_PROJECT_DIR")"
     [[ -n "$dir" ]] && echo "$dir"
 }
@@ -178,6 +188,13 @@ REQUIRED_TOOLS=(
     "plugins/session/tools/push_retry.py"
     "plugins/session/tools/jsonl_reader.py"
     "plugins/session/tools/event_store.py"
+    # Shared resolvers — every save path depends on them since the 2026-08-07
+    # detector consolidation. Absent, the pipeline must report the documented
+    # partial-install failure (exit 3 + manual fallback), not a bare
+    # command-not-found from the resolver wrapper.
+    "plugins/session/tools/project-root.sh"
+    "plugins/session/tools/project_root.py"
+    "plugins/session/tools/workspace_manifest.py"
 )
 MISSING=()
 for rel in "${REQUIRED_TOOLS[@]}"; do

--- a/plugins/session/tools/save-session.sh
+++ b/plugins/session/tools/save-session.sh
@@ -9,41 +9,24 @@ set -euo pipefail
 # CONFIGURATION
 # ==============================================================================
 
-# Multi-layered project directory detection
+# Shared project-root resolver (single source of truth for root detection)
+source "$(dirname "$0")/project-root.sh"
+
+# Multi-layered project directory detection (env, git-with-Memory, upward
+# walk; NO $HOME guard — historical, pinned by Test 9b). Hard-fails with
+# remediation text when nothing resolves.
 detect_project_dir() {
-    # Layer 1: Use CLAUDE_PROJECT_DIR if set (hook invocation)
-    if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-        echo "$CLAUDE_PROJECT_DIR"
-        return 0
+    local dir
+    dir="$(asha_detect_project_root "env,git,walk" 0)"
+    if [[ -z "$dir" ]]; then
+        echo "[ERROR] Cannot detect project directory. Tried:" >&2
+        echo "  1. CLAUDE_PROJECT_DIR environment variable (not set)" >&2
+        echo "  2. Git root with Memory/ directory (not found)" >&2
+        echo "  3. Upward search for Memory/ directory (not found)" >&2
+        return 1
     fi
-
-    # Layer 2: Try git root (manual invocation within git repo)
-    if command -v git >/dev/null 2>&1; then
-        local git_root
-        git_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-        if [[ -n "$git_root" ]] && [[ -d "$git_root/Memory" ]]; then
-            echo "$git_root"
-            return 0
-        fi
-    fi
-
-    # Layer 3: Search upward for Memory/ directory
-    local search_dir
-    search_dir="$(pwd)"
-    while [[ "$search_dir" != "/" ]]; do
-        if [[ -d "$search_dir/Memory" ]]; then
-            echo "$search_dir"
-            return 0
-        fi
-        search_dir="$(dirname "$search_dir")"
-    done
-
-    # Layer 4: All detection methods failed
-    echo "[ERROR] Cannot detect project directory. Tried:" >&2
-    echo "  1. CLAUDE_PROJECT_DIR environment variable (not set)" >&2
-    echo "  2. Git root with Memory/ directory (not found)" >&2
-    echo "  3. Upward search for Memory/ directory (not found)" >&2
-    return 1
+    echo "$dir"
+    return 0
 }
 
 PROJECT_DIR=$(detect_project_dir) || exit 1

--- a/plugins/session/tools/save-session.sh
+++ b/plugins/session/tools/save-session.sh
@@ -9,8 +9,11 @@ set -euo pipefail
 # CONFIGURATION
 # ==============================================================================
 
-# Shared project-root resolver (single source of truth for root detection)
-source "$(dirname "$0")/project-root.sh"
+# Shared project-root resolver (single source of truth for root detection).
+# BASH_SOURCE, not $0: correct when sourced by a wrapper or invoked through a
+# symlink to this file (an individual-file symlink mount is a shipped install
+# shape). Parameter expansion avoids an external `dirname` dependency.
+source "${BASH_SOURCE[0]%/*}/project-root.sh"
 
 # Multi-layered project directory detection (env, git-with-Memory, upward
 # walk; NO $HOME guard — historical, pinned by Test 9b). Hard-fails with

--- a/tests/python/test_project_root.py
+++ b/tests/python/test_project_root.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Tests for project_root (workspace v1, delivery issue 2 — issue #33).
+
+Two surfaces:
+1. detect_project_root — the ONE shared Python resolver the historical
+   detectors (pattern_analyzer, event_store, learnings_manager) now delegate
+   to, parameterized so each keeps its exact historical layer set.
+2. detect_workspace — the NEW workspace walk: upward from a start dir for
+   .asha/workspace.json, stopping BEFORE $HOME and BEFORE the filesystem
+   root (both exclusive, canonical comparison); a found manifest is parsed
+   by workspace_manifest; an INVALID manifest is a typed verdict, never a
+   silent keep-walking fallback. Nothing consumes the result yet — this
+   increment ships the primitive only.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import project_root as pr  # type: ignore[reportMissingImports]  # noqa: E402
+
+
+def _write_manifest(root: Path, data=None) -> None:
+    (root / ".asha").mkdir(parents=True, exist_ok=True)
+    payload = data if data is not None else {"version": 1, "workspace_name": "w"}
+    (root / ".asha" / "workspace.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+class DetectProjectRootTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_pr_"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, True))
+        self._env = os.environ.get("CLAUDE_PROJECT_DIR")
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        self.addCleanup(self._restore_env)
+
+    def _restore_env(self):
+        if self._env is None:
+            os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        else:
+            os.environ["CLAUDE_PROJECT_DIR"] = self._env
+
+    def test_env_layer_is_validated(self):
+        # Python detectors validate CLAUDE_PROJECT_DIR against Memory/
+        # (unlike the bash detectors) — historical, must stay.
+        plain = self.tmp / "plain"
+        plain.mkdir()
+        os.environ["CLAUDE_PROJECT_DIR"] = str(plain)
+        got = pr.detect_project_root(use_git=False, walk_base=None, on_fail="none")
+        self.assertIsNone(got)
+
+    def test_env_layer_accepts_project_with_memory(self):
+        proj = self.tmp / "proj"
+        (proj / "Memory").mkdir(parents=True)
+        os.environ["CLAUDE_PROJECT_DIR"] = str(proj)
+        got = pr.detect_project_root(use_git=False, walk_base=None, on_fail="none")
+        self.assertEqual(got, proj)
+
+    def test_argv_scan_validated_and_wins(self):
+        proj = self.tmp / "proj"
+        (proj / "Memory").mkdir(parents=True)
+        other = self.tmp / "other"
+        (other / "Memory").mkdir(parents=True)
+        os.environ["CLAUDE_PROJECT_DIR"] = str(other)
+        got = pr.detect_project_root(
+            argv=["--project-dir", str(proj)],
+            use_git=False, walk_base=None, on_fail="none",
+        )
+        self.assertEqual(got, proj.resolve())
+
+    def test_argv_scan_equals_form(self):
+        proj = self.tmp / "proj"
+        (proj / "Memory").mkdir(parents=True)
+        got = pr.detect_project_root(
+            argv=[f"--project-dir={proj}"],
+            use_git=False, walk_base=None, on_fail="none",
+        )
+        self.assertEqual(got, proj.resolve())
+
+    def test_argv_invalid_falls_through(self):
+        plain = self.tmp / "plain"
+        plain.mkdir()
+        got = pr.detect_project_root(
+            argv=["--project-dir", str(plain)],
+            use_git=False, walk_base=None, on_fail="none",
+        )
+        self.assertIsNone(got)
+
+    def test_walk_finds_memory_ancestor(self):
+        proj = self.tmp / "proj"
+        (proj / "Memory").mkdir(parents=True)
+        sub = proj / "a" / "b"
+        sub.mkdir(parents=True)
+        got = pr.detect_project_root(
+            use_env=False, use_git=False, walk_base=sub, on_fail="none"
+        )
+        self.assertEqual(got, sub.resolve().parents[1])
+
+    def test_on_fail_raise_matches_historical_message(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            pr.detect_project_root(
+                use_env=False, use_git=False,
+                walk_base=self.tmp / "nowhere-real",
+                on_fail="raise",
+            )
+        self.assertIn("Cannot detect project root", str(ctx.exception))
+
+    def test_on_fail_none_returns_none(self):
+        got = pr.detect_project_root(
+            use_env=False, use_git=False, walk_base=None, on_fail="none"
+        )
+        self.assertIsNone(got)
+
+
+class DetectWorkspaceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_ws_")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, True))
+        # Point $HOME inside the sandbox so home-exclusion is testable.
+        self._home = os.environ.get("HOME")
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        os.environ["HOME"] = str(self.home)
+        self.addCleanup(self._restore_home)
+
+    def _restore_home(self):
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+    def test_workspace_found_from_nested_cwd(self):
+        ws = self.home / "Code" / "Thallus"
+        child = ws / "egregore" / "src"
+        child.mkdir(parents=True)
+        _write_manifest(ws)
+        det = pr.detect_workspace(start=child)
+        self.assertEqual(det.root, ws)
+        self.assertIsNotNone(det.manifest)
+        self.assertEqual(det.errors, [])
+        self.assertEqual(det.manifest["workspace_name"], "w")
+
+    def test_no_manifest_anywhere_is_clean_none(self):
+        lone = self.home / "Code" / "solo"
+        lone.mkdir(parents=True)
+        det = pr.detect_workspace(start=lone)
+        self.assertIsNone(det.root)
+        self.assertIsNone(det.manifest)
+        self.assertEqual(det.errors, [])
+
+    def test_home_is_excluded(self):
+        # ~/.asha/workspace.json must NEVER make $HOME a workspace — the
+        # user-scope config dir exists for every asha install.
+        _write_manifest(self.home)
+        start = self.home / "Code" / "proj"
+        start.mkdir(parents=True)
+        det = pr.detect_workspace(start=start)
+        self.assertIsNone(det.root)
+        self.assertEqual(det.errors, [])
+
+    def test_start_at_home_itself_finds_nothing(self):
+        _write_manifest(self.home)
+        det = pr.detect_workspace(start=self.home)
+        self.assertIsNone(det.root)
+
+    def test_symlinked_home_compared_canonically(self):
+        # Entering $HOME through a symlink spelling must not defeat the
+        # exclusion (canonical comparison, per the ratified proposal).
+        alias = self.tmp / "home-alias"
+        alias.symlink_to(self.home)
+        _write_manifest(self.home)
+        start = alias / "Code" / "proj"
+        (self.home / "Code" / "proj").mkdir(parents=True)
+        det = pr.detect_workspace(start=start)
+        self.assertIsNone(det.root)
+
+    def test_invalid_manifest_is_typed_verdict_not_fallthrough(self):
+        # Fail closed: a broken workspace surfaces as a verdict; the walk
+        # must NOT keep climbing to a higher (valid) workspace.
+        outer = self.home / "Code"
+        inner = outer / "Thallus"
+        child = inner / "egregore"
+        child.mkdir(parents=True)
+        _write_manifest(outer)                      # valid, above
+        _write_manifest(inner, {"version": 2})      # invalid, nearer
+        det = pr.detect_workspace(start=child)
+        self.assertEqual(det.root, inner)
+        self.assertIsNone(det.manifest)
+        self.assertTrue(det.errors)
+        codes = {e.code for e in det.errors}
+        self.assertIn("unsupported_version", codes)
+
+    def test_unreadable_manifest_is_typed(self):
+        ws = self.home / "Code" / "ws"
+        child = ws / "repo"
+        child.mkdir(parents=True)
+        _write_manifest(ws)
+        path = ws / ".asha" / "workspace.json"
+        path.chmod(0o000)
+        self.addCleanup(lambda: path.chmod(0o644))
+        det = pr.detect_workspace(start=child)
+        self.assertEqual(det.root, ws)
+        self.assertIsNone(det.manifest)
+        self.assertEqual({e.code for e in det.errors}, {"unreadable"})
+
+    def test_start_dir_itself_can_be_workspace_root(self):
+        ws = self.home / "Code" / "ws"
+        ws.mkdir(parents=True)
+        _write_manifest(ws)
+        det = pr.detect_workspace(start=ws)
+        self.assertEqual(det.root, ws)
+        self.assertIsNotNone(det.manifest)
+
+
+class WorkspaceCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_wscli_")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, True))
+        self._home = os.environ.get("HOME")
+        os.environ["HOME"] = str(self.tmp / "home")
+        (self.tmp / "home").mkdir()
+        self.addCleanup(self._restore_home)
+
+    def _restore_home(self):
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+    def _run(self, argv):
+        import contextlib
+        import io
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            rc = pr.main(argv)
+        return rc, out.getvalue()
+
+    def test_cli_reports_workspace(self):
+        ws = self.tmp / "home" / "ws"
+        child = ws / "repo"
+        child.mkdir(parents=True)
+        _write_manifest(ws)
+        rc, out = self._run(["project_root.py", "workspace", "--start", str(child)])
+        self.assertEqual(rc, 0)
+        verdict = json.loads(out)
+        self.assertEqual(verdict["workspace_root"], str(ws))
+        self.assertTrue(verdict["ok"])
+
+    def test_cli_reports_no_workspace(self):
+        lone = self.tmp / "home" / "solo"
+        lone.mkdir(parents=True)
+        rc, out = self._run(["project_root.py", "workspace", "--start", str(lone)])
+        self.assertEqual(rc, 0)
+        verdict = json.loads(out)
+        self.assertIsNone(verdict["workspace_root"])
+        self.assertTrue(verdict["ok"])
+
+    def test_cli_invalid_manifest_exits_one(self):
+        ws = self.tmp / "home" / "ws"
+        child = ws / "repo"
+        child.mkdir(parents=True)
+        _write_manifest(ws, {"version": 99})
+        rc, out = self._run(["project_root.py", "workspace", "--start", str(child)])
+        self.assertEqual(rc, 1)
+        verdict = json.loads(out)
+        self.assertEqual(verdict["workspace_root"], str(ws))
+        self.assertFalse(verdict["ok"])
+        self.assertTrue(verdict["errors"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_project_root.py
+++ b/tests/python/test_project_root.py
@@ -35,6 +35,35 @@ def _write_manifest(root: Path, data=None) -> None:
     )
 
 
+class SiblingImportTests(unittest.TestCase):
+    """Pass-2: the rewired detectors must import their sibling resolver even
+    when tools/ is not already on sys.path (importlib/embedded loaders)."""
+
+    def test_pattern_analyzer_imports_without_tools_on_syspath(self):
+        import subprocess as sp
+        for module in ("pattern_analyzer", "event_store", "learnings_manager"):
+            path = TOOLS_DIR / f"{module}.py"
+            code = (
+                "import importlib.util,sys;"
+                f"spec=importlib.util.spec_from_file_location('probe_{module}',"
+                f" r'{path}');"
+                "m=importlib.util.module_from_spec(spec);"
+                "spec.loader.exec_module(m);"
+                "print('ok')"
+            )
+            env = dict(os.environ)
+            env["CLAUDE_PROJECT_DIR"] = str(self._project())
+            res = sp.run([sys.executable, "-c", code], capture_output=True,
+                         text=True, env=env)
+            self.assertIn("ok", res.stdout, f"{module}: {res.stderr[-400:]}")
+
+    def _project(self) -> Path:
+        tmp = Path(tempfile.mkdtemp(prefix="asha_sib_"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(tmp, True))
+        (tmp / "Memory" / "events").mkdir(parents=True)
+        return tmp
+
+
 class DetectProjectRootTests(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="asha_pr_"))
@@ -220,6 +249,62 @@ class DetectWorkspaceTests(unittest.TestCase):
         self.assertEqual(det.root, ws)
         self.assertIsNotNone(det.manifest)
 
+    # -- pass-2 (PR #34 review): the walk must be TOTAL and fail closed ----
+
+    def test_manifest_path_that_is_a_directory_is_typed_not_skipped(self):
+        # exists-but-not-a-regular-file must NOT read as "no manifest here"
+        # and let the walk climb to a higher workspace.
+        outer = self.home / "Code"
+        inner = outer / "ws"
+        child = inner / "repo"
+        child.mkdir(parents=True)
+        _write_manifest(outer)
+        (inner / ".asha" / "workspace.json").mkdir(parents=True)
+        det = pr.detect_workspace(start=child)
+        self.assertEqual(det.root, inner)
+        self.assertIsNone(det.manifest)
+        self.assertEqual({e.code for e in det.errors}, {"not_a_file"})
+
+    def test_broken_symlink_manifest_is_typed(self):
+        ws = self.home / "Code" / "ws"
+        child = ws / "repo"
+        child.mkdir(parents=True)
+        (ws / ".asha").mkdir()
+        (ws / ".asha" / "workspace.json").symlink_to(ws / "nonexistent.json")
+        det = pr.detect_workspace(start=child)
+        self.assertEqual(det.root, ws)
+        self.assertEqual({e.code for e in det.errors}, {"not_a_file"})
+
+    def test_permission_denied_ancestor_is_typed_not_traceback(self):
+        if os.geteuid() == 0:
+            self.skipTest("root bypasses directory permissions")
+        locked = self.home / "locked"
+        child = locked / "repo"
+        child.mkdir(parents=True)
+        locked.chmod(0o000)
+        self.addCleanup(lambda: locked.chmod(0o755))
+        det = pr.detect_workspace(start=child)
+        self.assertIsNone(det.manifest)
+        # Whether the unreadable ancestor trips start validation or the walk
+        # itself is an OS/stat detail; the pinned contract is a typed
+        # fail-closed verdict rather than a traceback out of a session hook.
+        self.assertTrue(det.errors)
+        self.assertIn(
+            det.errors[0].code, ("invalid_start", "walk_failed")
+        )
+
+    def test_nonexistent_start_is_typed(self):
+        det = pr.detect_workspace(start=self.home / "no" / "such" / "dir")
+        self.assertIsNone(det.root)
+        self.assertEqual({e.code for e in det.errors}, {"invalid_start"})
+
+    def test_file_as_start_is_typed(self):
+        f = self.home / "afile"
+        f.write_text("x", encoding="utf-8")
+        det = pr.detect_workspace(start=f)
+        self.assertIsNone(det.root)
+        self.assertEqual({e.code for e in det.errors}, {"invalid_start"})
+
 
 class WorkspaceCliTests(unittest.TestCase):
     def setUp(self):
@@ -263,6 +348,21 @@ class WorkspaceCliTests(unittest.TestCase):
         verdict = json.loads(out)
         self.assertIsNone(verdict["workspace_root"])
         self.assertTrue(verdict["ok"])
+
+    def test_cli_rejects_extra_arguments(self):
+        rc, _ = self._run(
+            ["project_root.py", "workspace", "--start", str(self.tmp), "EXTRA"]
+        )
+        self.assertEqual(rc, 2)
+
+    def test_cli_invalid_start_exits_one(self):
+        rc, out = self._run(
+            ["project_root.py", "workspace", "--start", "/definitely/not/here"]
+        )
+        self.assertEqual(rc, 1)
+        verdict = json.loads(out)
+        self.assertFalse(verdict["ok"])
+        self.assertEqual(verdict["errors"][0]["code"], "invalid_start")
 
     def test_cli_invalid_manifest_exits_one(self):
         ws = self.tmp / "home" / "ws"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -315,6 +315,37 @@ got="$(env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
     bash -c "source '$D9B_LIB' 2>/dev/null || true; ARG_PROJECT_DIR='$D9B_ROOT/fakehome'; $D9B_D3FN; resolve_project_dir || true")"
 chk9b d3_home_guard "$got" ""
 
+# --- pass-2 pins (PR #34 review): output fidelity + environment edges ---
+# Verbatim output: no canonicalization, trailing slashes and relative forms
+# survive exactly as the historical detectors emitted them.
+got="$(env HOME="$D9B_ROOT/fakehome" CLAUDE_PROJECT_DIR="$D9B_ROOT/proj///" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_trailing_slashes_verbatim "$got" "$D9B_ROOT/proj///"
+got="$(cd "$D9B_ROOT" && env HOME="$D9B_ROOT/fakehome" CLAUDE_PROJECT_DIR="proj" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_relative_verbatim "$got" "proj"
+# Empty string is NOT set: the env layer must fall through, not return "".
+got="$(cd "$D9B_ROOT/proj/sub" && env HOME="$D9B_ROOT/fakehome" CLAUDE_PROJECT_DIR="" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_empty_env_falls_through "$got" "$D9B_ROOT/proj"
+# git absent from PATH must degrade quietly (historical `command -v git`),
+# and the library must not need external binaries to be sourced.
+got="$(cd "$D9B_ROOT/proj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    PATH="/nonexistent" /bin/bash -c "source '$D9B_COMMON'; detect_project_dir" 2>/dev/null || true)"
+chk9b d1_no_git_no_path "$got" ""
+got="$(cd "$D9B_ROOT/proj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    PATH="/nonexistent" /bin/bash -c "source '$D9B_COMMON'; detect_project_dir" >/dev/null 2>&1; echo "$?")"
+chk9b d1_no_path_rc "$got" "0"
+# A hostile command_not_found_handle must not fabricate a project root.
+got="$(cd "$D9B_ROOT/plain" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "command_not_found_handle() { echo '$D9B_ROOT/proj'; return 0; }
+             PATH=/nonexistent; source '$D9B_COMMON'; detect_project_dir" 2>/dev/null || true)"
+chk9b d1_no_cnf_fabrication "$got" ""
+# resolve_project_dir returns rc 0 on success (consumer uses `|| true`).
+got="$(env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB'; ARG_PROJECT_DIR='$D9B_ROOT/plain'; $D9B_D3FN; resolve_project_dir >/dev/null; echo \$?" || true)"
+chk9b d3_success_rc "$got" "0"
+
 rm -rf "$D9B_ROOT"
 if [[ $D9B_OK -eq 1 ]]; then
     echo -e "${GREEN}PASS${NC}"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -238,6 +238,94 @@ else
 fi
 
 # ============================================================================
+# Test 9b: Project-root detector semantics pinned (workspace v1, issue #33)
+# ============================================================================
+# Byte-identical pins captured BEFORE detector consolidation. Each pin records
+# a load-bearing behavior of one of the three bash detectors, INCLUDING their
+# divergences (e.g. save-session's walk + missing HOME guard) — consolidation
+# must preserve these exactly, not "fix" them.
+echo -n "Test 9b: project-root detector layer semantics are pinned... "
+D9B_OK=1; D9B_WHY=""
+chk9b() { [[ "$2" == "$3" ]] || { D9B_OK=0; D9B_WHY="$D9B_WHY $1(got='$2' want='$3')"; }; }
+
+D9B_ROOT="$(mktemp -d)"
+mkdir -p "$D9B_ROOT/proj/Memory" "$D9B_ROOT/proj/sub" \
+         "$D9B_ROOT/walkproj/Memory" "$D9B_ROOT/walkproj/sub" \
+         "$D9B_ROOT/plain" "$D9B_ROOT/gitnomem" "$D9B_ROOT/fakehome"
+git -C "$D9B_ROOT/proj" init -q
+git -C "$D9B_ROOT/gitnomem" init -q
+
+D9B_COMMON="$REPO_ROOT/plugins/session/hooks/handlers/common.sh"
+
+# --- DETECTOR 1: hooks/handlers/common.sh detect_project_dir ---
+# env layer is VERBATIM and unvalidated (no Memory/ check)
+got="$(env HOME="$D9B_ROOT/fakehome" CLAUDE_PROJECT_DIR="$D9B_ROOT/plain" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_env_unvalidated "$got" "$D9B_ROOT/plain"
+# git layer fires only when the toplevel contains Memory/
+got="$(cd "$D9B_ROOT/proj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_git_with_memory "$got" "$D9B_ROOT/proj"
+got="$(cd "$D9B_ROOT/gitnomem" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_git_without_memory "$got" ""
+# NO upward walk: an ancestor Memory/ outside git is invisible to detector 1
+got="$(cd "$D9B_ROOT/walkproj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_no_upward_walk "$got" ""
+# $HOME is never a project (identity layer)
+got="$(env HOME="$D9B_ROOT/fakehome" CLAUDE_PROJECT_DIR="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_COMMON'; detect_project_dir")"
+chk9b d1_home_guard "$got" ""
+
+# --- DETECTOR 2: tools/save-session.sh detect_project_dir (extracted; the
+# script body runs a save on execution, so the function is pinned in
+# isolation) ---
+# The extraction subshell sources the shared resolver so these pins keep
+# working across the consolidation (wrapper delegates to the lib).
+D9B_LIB="$REPO_ROOT/plugins/session/tools/project-root.sh"
+D9B_D2FN="$(sed -n '/^detect_project_dir()/,/^}$/p' "$REPO_ROOT/plugins/session/tools/save-session.sh")"
+# layer 3: upward walk from cwd for Memory/ (detector 1 lacks this)
+got="$(cd "$D9B_ROOT/walkproj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; $D9B_D2FN; detect_project_dir 2>/dev/null")"
+chk9b d2_upward_walk "$got" "$D9B_ROOT/walkproj"
+# divergence pin: NO home guard — a walk landing on \$HOME is returned as-is
+got="$(cd "$D9B_ROOT/walkproj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/walkproj" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; $D9B_D2FN; detect_project_dir 2>/dev/null")"
+chk9b d2_no_home_guard "$got" "$D9B_ROOT/walkproj"
+# hard failure: rc=1 and no stdout when nothing resolves
+got="$(cd "$D9B_ROOT/plain" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; $D9B_D2FN; detect_project_dir 2>/dev/null")" && d2rc=0 || d2rc=$?
+chk9b d2_fail_output "$got" ""
+chk9b d2_fail_rc "$d2rc" "1"
+
+# --- DETECTOR 3: tools/save-preflight-env.sh resolve_project_dir (extracted;
+# references file-scope ARG_PROJECT_DIR) ---
+D9B_D3FN="$(sed -n '/^resolve_project_dir()/,/^}$/p' "$REPO_ROOT/plugins/session/tools/save-preflight-env.sh")"
+# layer 0: explicit --project-dir wins, unvalidated
+got="$(env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; ARG_PROJECT_DIR='$D9B_ROOT/plain'; $D9B_D3FN; resolve_project_dir || true")"
+chk9b d3_arg_unvalidated "$got" "$D9B_ROOT/plain"
+# layer 3: upward walk (union of detectors 1+2)
+got="$(cd "$D9B_ROOT/walkproj/sub" && env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; ARG_PROJECT_DIR=''; $D9B_D3FN; resolve_project_dir || true")"
+chk9b d3_upward_walk "$got" "$D9B_ROOT/walkproj"
+# home guard present (unlike detector 2)
+got="$(env -u CLAUDE_PROJECT_DIR HOME="$D9B_ROOT/fakehome" \
+    bash -c "source '$D9B_LIB' 2>/dev/null || true; ARG_PROJECT_DIR='$D9B_ROOT/fakehome'; $D9B_D3FN; resolve_project_dir || true")"
+chk9b d3_home_guard "$got" ""
+
+rm -rf "$D9B_ROOT"
+if [[ $D9B_OK -eq 1 ]]; then
+    echo -e "${GREEN}PASS${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "  detector-pin mismatch:$D9B_WHY"
+    FAILED=$((FAILED + 1))
+fi
+
+# ============================================================================
 # Test 10: is_asha_initialized function
 # ============================================================================
 echo -n "Test 10: is_asha_initialized correctly detects initialization... "


### PR DESCRIPTION
Closes #33. Workspace v1 delivery issue 2, consuming the #31 validator.

## The inventory changed the scope

An exhaustive sweep found **24 project-root derivation sites, not the four the proposal assumed** — including **six full copies of the layered Memory-root algorithm with five distinct layer orders, no two byte-identical**. Workspace detection added to one would silently not propagate. Two facts worth flagging beyond this PR: under Codex/Copilot `CLAUDE_PROJECT_DIR` is never set, so the git-root-with-`Memory/` layer is the live path there; and two Python detectors walk from `__file__`, which under a symlink-mounted install can resolve into the asha tree itself.

## What changed

- **`tools/project-root.sh`** (new, source-scoped lib) — `asha_detect_project_root LAYERS HOME_GUARD [EXPLICIT]`. Callers declare their historical layer set (`env,git` / `env,git,walk`), failure policy stays with the caller.
- **`tools/project_root.py`** (new) — `detect_project_root(argv=, use_env=, use_git=, walk_base=, on_fail=)`. The Python detectors' historical divergence (env layer **validated** against `Memory/`, unlike bash) is preserved and documented, not "fixed".
- Six callers rewired to delegate: `common.sh`, `save-session.sh`, `save-preflight-env.sh`, `pattern_analyzer.py`, `event_store.py`, `learnings_manager.py`.
- **`detect_workspace()`** (new primitive, **consumed by nothing**) — upward walk for `.asha/workspace.json`; `$HOME` and `/` both exclusive with canonical comparison (a symlinked-home spelling cannot defeat the exclusion); first manifest wins; an invalid manifest is a typed fail-closed verdict rather than a keep-walking fallthrough that would be indistinguishable from "no workspace". CLI: `project_root.py workspace [--start DIR]`.

## Byte-identical evidence

Test 9b's 12 pins were written and confirmed **green against the pre-consolidation code**, then stayed green after the rewire. They pin the divergences deliberately: D1 has no walk and a $HOME guard and an unvalidated env layer; D2 has the walk but **no** $HOME guard and an `exit 1` contract; D3 has the arg layer plus walk plus guard. Detectors 2 and 3 previously had **zero** test coverage.

## Audit (the acceptance criterion)

Outside the two resolvers, **no site retains the layered algorithm** — verified by sweeps for `rev-parse --show-toplevel`, `Memory/`-validation, and upward-walk idioms. Exempt by design:

| Site | Why exempt |
|---|---|
| `verify.py` build-root | Different domain (package.json/Cargo.toml markers), never touches Memory/ |
| `issue-loop-preflight.sh` | Deliberate git-only refuse rail; must not gain fallbacks |
| 5 command-MD one-liners | Thin `${CLAUDE_PROJECT_DIR:-git toplevel/pwd}`, no layering; model-executed markdown |
| `save-commit-gate.sh`, `save-preflight-stop.sh` | Payload-`.cwd`-first ordering is intentional for hook-time accuracy |
| Python CLI `--project-dir` defaults | Receivers; the wired pipeline always passes the flag explicitly |

## Test plan

- [x] Test 9b (12 pins) green pre- and post-consolidation
- [x] 19 new tests in `tests/python/test_project_root.py` (RED-first)
- [x] Existing Python suites that force detector re-import (orphan detection, pattern-analyzer ×2, silence marker, learnings OKF) untouched and green
- [x] `./tests/run-tests.sh` 13/13; `validate-versions.sh` 5/5
- [ ] Codex adversarial pass over this commit before leaving draft

Session plugin 1.14.0 → 1.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)