### PR TITLE
feat: asha workspace status + doctor section (workspace v1, delivery issue 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This guide helps AI assistants (like Claude) understand the asha codebase struct
 
 | Plugin | Version | Domain | Description |
 |--------|---------|--------|-------------|
-| **Session** | v1.15.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Session** | v1.16.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Asha** | v2.1.0 | Identity | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Panel System** | v5.0.0 | Research | Multi-perspective analysis with persistence and resumption — 6 agents |
 | **Code** | v1.5.0 | Development | Code review, orchestration patterns, TDD, issue-to-merge loop — 5 agents, postgres skill |
@@ -919,6 +919,15 @@ git push -u origin <branch-name>
 ---
 
 ## Version History
+
+### Session v1.16.0 (2026-08-08) — `asha workspace status` + doctor section
+
+Workspace v1 delivery issue 3 (issue #35): first consumer of the detection
+primitive. New `workspace` dispatcher verb (thin lib/workspace.sh shim over
+`tools/workspace_status.py`), doctor workspace section (silent outside
+workspaces, fail-closed on invalid manifests), and the ratified manifest
+convention (committed in shared_git_root; untracked warns; invalid gets
+guided repair, never auto-fix). Suite 15 + 12 unit tests, tests-first.
 
 ### Session v1.15.0 (2026-08-07) — project-root consolidation + workspace walk
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ They form a pipeline, not an overlap: guardrails read session_state for in-fligh
 
 | Domain | Plugin | Version | Purpose |
 |--------|--------|---------|---------|
-| **Core** | `session` | v1.15.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Core** | `session` | v1.16.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Identity** | `asha` | v2.1.0 | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Research** | `panel-system` | v5.0.0 | Multi-perspective analysis, expert panels, decision-making — 6 agents |
 | **Development** | `code` | v1.5.0 | Code review, orchestration patterns, TDD, overnight issue-to-merge loop — 5 agents |
@@ -335,7 +335,7 @@ Create a ComfyUI workflow for: txt2img with upscaling
 
 **Plugin Name**: `session`
 **Commands**: `/session:init`, `/session:save`, `/session:status`, `/session:silence`, `/session:restore`, `/session:loop`
-**Version**: 1.15.0
+**Version**: 1.16.0
 **Domain**: Core
 
 Session coordination and memory persistence — the foundation layer other plugins build on. Learnings persist as an OKF concept bundle (`~/.asha/learnings/`, one file per learning) with auto-suggested `## Related` cross-links at `/save`; see [`docs/memory-architecture.md`](docs/memory-architecture.md).
@@ -563,6 +563,21 @@ Individual plugins licensed separately. See each plugin's LICENSE file (MIT thro
 ---
 
 ## Version History
+
+### Session v1.16.0 + `asha workspace status` — first workspace consumer (2026-08-08)
+
+Workspace v1 delivery issue 3 (issue #35). New dispatcher verb
+`asha workspace status [--json] [--start DIR]` (thin `lib/workspace.sh`
+shim; no new fallback chain — detection stays with the shared resolver) over
+new `plugins/session/tools/workspace_status.py`: manifest validity with
+typed errors verbatim, active child repository (cwd-resolved), per-repo
+presence/branch/dirty state (reported, never assumed), `shared_git_root`
+health, manifest trackedness. `asha doctor` gains the same as a section —
+silent outside workspaces, fail-closed on an invalid manifest. Implements
+the ratified open-question-1 decision: **manifest committed in
+`shared_git_root` by convention**; untracked warns, invalid prints guided
+repair (never auto-fix). Suite 15 (10 dispatcher/doctor cases) + 12 python
+unit tests, tests-first.
 
 ### Session v1.15.0 — project-root consolidation + workspace walk (2026-08-07)
 

--- a/bin/asha
+++ b/bin/asha
@@ -256,6 +256,8 @@ Usage:
                                    (--only ns,.. --out DIR --version X.Y.Z --dry-run --force)
   asha doctor [target] [--fix]     audit install health (claude|codex|copilot|all)
                                    (Claude Code's native doctor: asha claude doctor)
+  asha workspace status [--json]   report detected workspace (.asha/workspace.json),
+                                   declared repos, and manifest health
   asha init-repo [--dir D] [...]   scaffold agent/Copilot standards files into a repo
                                    (--dry-run | --check for CI | --force)
   asha calibration [args...]       inspect orchestration calibration metrics
@@ -307,6 +309,15 @@ if [[ "${1:-}" == "doctor" ]]; then
   # this wrapper as their contract; without it a failed write inside the verb
   # would print success and exit 0 (review finding on init-repo).
   ( set -euo pipefail; asha_doctor_main "$@" )
+  exit $?
+fi
+
+# Workspace inspection (workspace v1, issue #35). Verb-first.
+if [[ "${1:-}" == "workspace" ]]; then
+  shift
+  # shellcheck disable=SC1090
+  source "$ASHA_ROOT/lib/workspace.sh"
+  ( set -euo pipefail; asha_workspace_main "$@" )
   exit $?
 fi
 

--- a/docs/proposals/2026-08-06--workspace-memory.md
+++ b/docs/proposals/2026-08-06--workspace-memory.md
@@ -332,13 +332,14 @@ the gate.
 - No implicit `git init`, no implicit branch/worktree/PR creation, and no
   reliance on runtime policy hooks as a substitute for git review and CI.
 
-## Open questions (small, none block ratification)
+## Open questions
 
-1. Should the workspace manifest be committed in the workspace's
-   `shared_git_root` by convention? (asha's own repos gitignore `.asha/`
-   wholesale; target workspaces likely want the manifest versioned —
-   probably a documented convention plus a doctor warning, decided in v1.)
-   Note the consequence either way: a *committed* manifest plus fail-closed
-   validation means one teammate's typo hard-fails every session
-   workspace-wide, so the v1 decision should weigh a doctor-guided repair
-   path alongside the convention.
+1. **RESOLVED (Keeper, 2026-08-08; implemented in v1 issue #35)**: the
+   workspace manifest is **committed in `shared_git_root` by convention**.
+   `asha workspace status` and `asha doctor` warn when it is untracked
+   there; an invalid manifest is a typed error with **guided repair steps**
+   (never an auto-fix), which softens the accepted consequence that a
+   committed manifest plus fail-closed validation lets one teammate's typo
+   hard-fail every session workspace-wide until repaired. (asha's own repos
+   continue to gitignore `.asha/` — the convention binds workspaces, not
+   this toolkit's repositories.)

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -63,6 +63,29 @@ EOF
   local -a args=(--target "$target")
   [[ $fix -eq 1 ]] && args+=(--fix)
   # Child process, not sourced: drift-check is a standalone set -uo script
-  # that exits directly. Its exit code is the doctor contract.
-  bash "$MARKET_ROOT/bin/asha-drift-check.sh" "${args[@]}"
+  # that exits directly. rc captured with `|| rc=$?` because this runs under
+  # bin/asha's set -e wrapper — a bare non-zero here would skip the
+  # workspace section below.
+  local drift_rc=0
+  bash "$MARKET_ROOT/bin/asha-drift-check.sh" "${args[@]}" || drift_rc=$?
+  local ws_rc=0
+  _asha_doctor_workspace_section || ws_rc=$?
+  [[ $drift_rc -eq 0 && $ws_rc -eq 0 ]]
+}
+
+# Workspace v1 (issue #35): report workspace state from CWD. No workspace is
+# a silent pass; warnings print but pass; an invalid manifest FAILS doctor —
+# fail-closed, a broken workspace definition is install-grade breakage.
+_asha_doctor_workspace_section() {
+  local tool="$MARKET_ROOT/plugins/session/tools/workspace_status.py"
+  [[ -f "$tool" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  local out rc=0
+  out="$(python3 "$tool" 2>/dev/null)" || rc=$?
+  # Single-project mode: nothing to report, doctor stays quiet.
+  [[ $rc -eq 0 && "$out" == "workspace: none"* ]] && return 0
+  echo ""
+  echo "── Workspace (asha workspace status) ──"
+  printf '%s\n' "$out"
+  return $rc
 }

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -79,7 +79,14 @@ EOF
 _asha_doctor_workspace_section() {
   local tool="$MARKET_ROOT/plugins/session/tools/workspace_status.py"
   [[ -f "$tool" ]] || return 0
-  command -v python3 >/dev/null 2>&1 || return 0
+  if ! command -v python3 >/dev/null 2>&1; then
+    # Visible skip, not silence: an invalid manifest coexisting with a green
+    # doctor because python was missing would be a hidden gap (pass-2).
+    echo ""
+    echo "── Workspace (asha workspace status) ──"
+    echo "skipped: python3 unavailable — workspace manifest NOT validated"
+    return 0
+  fi
   local out rc=0
   out="$(python3 "$tool" 2>/dev/null)" || rc=$?
   # Single-project mode: nothing to report, doctor stays quiet.

--- a/lib/workspace.sh
+++ b/lib/workspace.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# lib/workspace.sh — `asha workspace` verb (workspace v1, issue #35).
+#
+# Usage:  asha workspace status [--json] [--start DIR]
+# Exit:   0 no-workspace or valid; 1 invalid manifest; 2 usage error.
+#
+# Thin shim over plugins/session/tools/workspace_status.py — detection and
+# enrichment live there (single source of truth; the dispatcher adds no
+# fallback chain of its own, preserving the PR #34 audit invariant).
+#
+# Does NOT `set -e` at source scope (callers own shell options; bin/asha
+# wraps invocations in a `set -euo pipefail` subshell). Sourced ONLY by
+# bin/asha, which guarantees ASHA_ROOT — deliberately no bootstrap
+# symlink-walk copy here (that duplication exists for engines that must
+# also run standalone; this one must not).
+#
+# Public entry point: asha_workspace_main "$@".
+
+_asha_workspace_usage() {
+  cat <<'EOF'
+asha workspace — workspace inspection (v1: status only)
+
+Usage:
+  asha workspace status [--json] [--start DIR]
+
+Reports the detected workspace (upward walk for .asha/workspace.json),
+manifest validity, active child repository, shared_git_root state, and
+declared repository health. The manifest is committed in shared_git_root
+by convention (ratified 2026-08-08) — status warns when it is untracked.
+
+Exit: 0 = no workspace, or a valid one (warnings do not fail);
+      1 = manifest invalid/unreadable (fail-closed, guided repair printed);
+      2 = usage error.
+EOF
+}
+
+asha_workspace_main() {
+  local root="${ASHA_ROOT:-${MARKET_ROOT:-}}"
+  if [[ -z "$root" ]]; then
+    echo "ERROR: ASHA_ROOT is not set (lib/workspace.sh is sourced by bin/asha only)" >&2
+    return 2
+  fi
+  case "${1:-}" in
+    status)
+      shift
+      if ! command -v python3 >/dev/null 2>&1; then
+        echo "ERROR: python3 is required for workspace status" >&2
+        return 1
+      fi
+      python3 "$root/plugins/session/tools/workspace_status.py" "$@"
+      ;;
+    -h|--help)
+      _asha_workspace_usage
+      return 0
+      ;;
+    "")
+      _asha_workspace_usage >&2
+      return 2
+      ;;
+    *)
+      echo "ERROR: unknown workspace subcommand: $1 (see: asha workspace --help)" >&2
+      return 2
+      ;;
+  esac
+}

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -1,6 +1,6 @@
 # Session
 
-**Version**: 1.15.0
+**Version**: 1.16.0
 
 Session management with memory persistence, pattern extraction, and operational quality.
 

--- a/plugins/session/tools/workspace_status.py
+++ b/plugins/session/tools/workspace_status.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+workspace_status.py — enriched workspace status (v1, issue #35).
+
+The first consumer of detect_workspace(): resolves the workspace from a
+start directory (default cwd), then enriches the verdict with read-only git
+state — active child repository, per-repo presence/branch/dirty state,
+shared_git_root health, and manifest trackedness.
+
+Ratified convention (Keeper, 2026-08-08; closes the proposal's open
+question 1): the manifest is COMMITTED in shared_git_root. Untracked is a
+WARNING; invalid is a typed ERROR with guided repair steps printed for
+humans — never an auto-fix.
+
+Exit contract (consumed by lib/workspace.sh and lib/doctor.sh):
+  0 — no workspace, or a valid one (warnings do not flip the exit code)
+  1 — workspace detected but manifest invalid/unreadable, or detection error
+  2 — usage error
+Warnings vs errors: an error means the workspace cannot be trusted at all
+(fail closed); a warning is actionable but non-blocking.
+"""
+
+import contextlib
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import project_root  # noqa: E402
+
+
+def _git_lines(args: List[str], cwd: Optional[Path] = None) -> Optional[str]:
+    """Run a read-only git command; None on any failure (absent git, not a
+    repo, permission). Status must never crash on a sick repository."""
+    try:
+        res = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    return res.stdout.strip()
+
+
+def _is_git_worktree(path: Path) -> bool:
+    out = _git_lines(["-C", str(path), "rev-parse", "--is-inside-work-tree"])
+    return out == "true"
+
+
+def _repo_state(path: Path) -> dict:
+    state = {
+        "exists": path.is_dir(),
+        "is_git_worktree": False,
+        "branch": None,
+        "dirty": None,
+    }
+    if not state["exists"]:
+        return state
+    if not _is_git_worktree(path):
+        return state
+    state["is_git_worktree"] = True
+    state["branch"] = _git_lines(
+        ["-C", str(path), "rev-parse", "--abbrev-ref", "HEAD"]
+    )
+    porcelain = _git_lines(["-C", str(path), "status", "--porcelain"])
+    state["dirty"] = None if porcelain is None else bool(porcelain)
+    return state
+
+
+def _active_repository(ws_root: Path, repos: List[dict],
+                       start: Path) -> Optional[str]:
+    """Deepest declared repository whose tree contains start. cwd-only per
+    the ratified proposal (explicit child naming is a v2 concern)."""
+    try:
+        resolved = start.resolve()
+    except OSError:
+        return None
+    best: Optional[str] = None
+    best_depth = -1
+    for entry in repos:
+        rel = entry.get("path")
+        if not isinstance(rel, str):
+            continue
+        candidate = (ws_root / rel).resolve()
+        if candidate == resolved or candidate in resolved.parents:
+            depth = len(candidate.parts)
+            if depth > best_depth:
+                best, best_depth = rel, depth
+    return best
+
+
+def build_status(start: Optional[Path] = None) -> dict:
+    """Pure-read report. Never raises; every failure is typed in-report."""
+    det = project_root.detect_workspace(start=start)
+    report = {
+        "workspace_root": str(det.root) if det.root else None,
+        "workspace_name": None,
+        "ok": not det.errors and (det.root is None or det.manifest is not None),
+        "errors": [e._asdict() for e in det.errors],
+        "warnings": [],
+        "active_repository": None,
+        "memory": None,
+        "shared_git_root": None,
+        "repositories": [],
+        "manifest_tracked": None,
+    }
+    if det.root is None or det.manifest is None:
+        return report
+
+    manifest = det.manifest
+    ws_root = det.root
+    report["workspace_name"] = manifest.get("workspace_name")
+    report["memory"] = manifest.get("memory")
+
+    def warn(code: str, message: str) -> None:
+        report["warnings"].append({"code": code, "message": message})
+
+    # shared_git_root state — where workspace memory commits land.
+    sgr_rel = manifest.get("memory", {}).get("shared_git_root", ".")
+    sgr_path = (ws_root / sgr_rel).resolve() if sgr_rel != "." else ws_root
+    sgr_is_git = _is_git_worktree(sgr_path)
+    sgr_porcelain = (
+        _git_lines(["-C", str(sgr_path), "status", "--porcelain"])
+        if sgr_is_git else None
+    )
+    report["shared_git_root"] = {
+        "path": str(sgr_path),
+        "is_git_worktree": sgr_is_git,
+        "dirty": bool(sgr_porcelain) if sgr_porcelain is not None else None,
+    }
+    if not sgr_is_git:
+        warn("shared_git_root_not_git",
+             f"shared_git_root ({sgr_path}) is not a git worktree — "
+             f"workspace memory commits are unavailable until it is")
+
+    # Manifest trackedness — ratified convention: committed in shared_git_root.
+    if sgr_is_git:
+        rel_manifest = None
+        try:
+            rel_manifest = (ws_root / ".asha" / "workspace.json").resolve() \
+                .relative_to(sgr_path)
+        except ValueError:
+            pass
+        if rel_manifest is not None:
+            tracked = _git_lines(
+                ["-C", str(sgr_path), "ls-files", "--error-unmatch",
+                 str(rel_manifest)]
+            )
+            report["manifest_tracked"] = tracked is not None
+            if tracked is None:
+                warn("manifest_untracked",
+                     "the workspace manifest is not committed in "
+                     "shared_git_root — the ratified convention is to track "
+                     "it so the workspace definition is shared "
+                     f"(git -C {sgr_path} add {rel_manifest})")
+
+    # Declared repositories — reported, never assumed.
+    start_path = Path(start if start is not None else Path.cwd())
+    repos = manifest.get("repositories", [])
+    for entry in repos:
+        rel = entry.get("path")
+        if not isinstance(rel, str):
+            continue
+        state = _repo_state(ws_root / rel)
+        state["path"] = rel
+        if "role" in entry:
+            state["role"] = entry["role"]
+        report["repositories"].append(state)
+        if not state["exists"]:
+            warn("repo_missing",
+                 f"declared repository {rel} does not exist under the "
+                 f"workspace root")
+        elif not state["is_git_worktree"]:
+            warn("repo_not_git",
+                 f"declared repository {rel} exists but is not a git "
+                 f"worktree")
+
+    report["active_repository"] = _active_repository(
+        ws_root, repos, start_path
+    )
+    return report
+
+
+def _render_human(report: dict) -> str:
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        if report["workspace_root"] is None and not report["errors"]:
+            print("workspace: none (single-project mode)")
+        elif not report["ok"]:
+            print(f"workspace: INVALID at {report['workspace_root'] or '?'}")
+            for e in report["errors"]:
+                field = f" [{e['field']}]" if e.get("field") else ""
+                print(f"  error: {e['code']}{field} — {e['message']}")
+            print("  repair: edit .asha/workspace.json at the workspace "
+                  "root, then validate with:")
+            print("    python3 plugins/session/tools/workspace_manifest.py "
+                  "<path-to-workspace.json>")
+            print("  (fail-closed by design: no partial workspace behavior "
+                  "until the manifest is valid)")
+        else:
+            print(f"workspace: {report['workspace_name']} "
+                  f"at {report['workspace_root']}")
+            active = report["active_repository"] or "(workspace root)"
+            print(f"  active repository: {active}")
+            sgr = report["shared_git_root"] or {}
+            state = "git" if sgr.get("is_git_worktree") else "NOT GIT"
+            dirty = ""
+            if sgr.get("dirty") is not None:
+                dirty = ", dirty" if sgr["dirty"] else ", clean"
+            print(f"  shared_git_root: {sgr.get('path')} ({state}{dirty})")
+            if report["manifest_tracked"] is not None:
+                print(f"  manifest tracked: "
+                      f"{'yes' if report['manifest_tracked'] else 'NO'}")
+            for r in report["repositories"]:
+                if not r["exists"]:
+                    line = "MISSING"
+                elif not r["is_git_worktree"]:
+                    line = "exists, not git"
+                else:
+                    flags = r["branch"] or "?"
+                    if r["dirty"] is not None:
+                        flags += ", dirty" if r["dirty"] else ", clean"
+                    line = flags
+                print(f"  repo {r['path']}: {line}")
+        for w in report["warnings"]:
+            print(f"  warning: {w['code']} — {w['message']}")
+    return out.getvalue()
+
+
+def main(argv: List[str]) -> int:
+    args = argv[1:]
+    as_json = False
+    start: Optional[Path] = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--json":
+            as_json = True
+        elif args[i] == "--start" and i + 1 < len(args):
+            start = Path(args[i + 1])
+            i += 1
+        elif args[i].startswith("--start="):
+            start = Path(args[i].split("=", 1)[1])
+        else:
+            print("usage: workspace_status.py [--json] [--start DIR]",
+                  file=sys.stderr)
+            return 2
+        i += 1
+
+    report = build_status(start=start)
+    if as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        sys.stdout.write(_render_human(report))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/plugins/session/tools/workspace_status.py
+++ b/plugins/session/tools/workspace_status.py
@@ -49,27 +49,57 @@ def _git_lines(args: List[str], cwd: Optional[Path] = None) -> Optional[str]:
     return res.stdout.strip()
 
 
-def _is_git_worktree(path: Path) -> bool:
-    out = _git_lines(["-C", str(path), "rev-parse", "--is-inside-work-tree"])
-    return out == "true"
+def _is_repo_root(path: Path) -> bool:
+    """True iff path is itself the toplevel of a git worktree.
+
+    is-inside-work-tree is NOT enough: it answers true for any plain
+    subdirectory of the surrounding workspace repo, which would report the
+    parent's branch/dirty state as the child's (pass-2 blocking finding).
+    """
+    out = _git_lines(["-C", str(path), "rev-parse", "--show-toplevel"])
+    if out is None:
+        return False
+    try:
+        return Path(out).resolve() == path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
-def _repo_state(path: Path) -> dict:
+def _contained(candidate: Path, root: Path) -> Optional[Path]:
+    """Resolved candidate iff it stays inside resolved root; else None.
+
+    Canonical, not lexical: a declared path that is a symlink out of the
+    workspace must not have git state read from the foreign target.
+    """
+    try:
+        c = candidate.resolve()
+        r = root.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if c == r or r in c.parents:
+        return c
+    return None
+
+
+def _repo_state(path: Path, resolved: Optional[Path]) -> dict:
     state = {
         "exists": path.is_dir(),
         "is_git_worktree": False,
         "branch": None,
         "dirty": None,
     }
-    if not state["exists"]:
+    if not state["exists"] or resolved is None:
         return state
-    if not _is_git_worktree(path):
+    if not _is_repo_root(resolved):
         return state
     state["is_git_worktree"] = True
-    state["branch"] = _git_lines(
-        ["-C", str(path), "rev-parse", "--abbrev-ref", "HEAD"]
+    # Unborn HEAD: abbrev-ref fails before the first commit, but the
+    # symbolic branch name is still known.
+    state["branch"] = (
+        _git_lines(["-C", str(resolved), "rev-parse", "--abbrev-ref", "HEAD"])
+        or _git_lines(["-C", str(resolved), "symbolic-ref", "--short", "HEAD"])
     )
-    porcelain = _git_lines(["-C", str(path), "status", "--porcelain"])
+    porcelain = _git_lines(["-C", str(resolved), "status", "--porcelain"])
     state["dirty"] = None if porcelain is None else bool(porcelain)
     return state
 
@@ -77,10 +107,11 @@ def _repo_state(path: Path) -> dict:
 def _active_repository(ws_root: Path, repos: List[dict],
                        start: Path) -> Optional[str]:
     """Deepest declared repository whose tree contains start. cwd-only per
-    the ratified proposal (explicit child naming is a v2 concern)."""
+    the ratified proposal (explicit child naming is a v2 concern). Escaped
+    (out-of-workspace) declarations never qualify."""
     try:
         resolved = start.resolve()
-    except OSError:
+    except (OSError, RuntimeError, ValueError):
         return None
     best: Optional[str] = None
     best_depth = -1
@@ -88,7 +119,9 @@ def _active_repository(ws_root: Path, repos: List[dict],
         rel = entry.get("path")
         if not isinstance(rel, str):
             continue
-        candidate = (ws_root / rel).resolve()
+        candidate = _contained(ws_root / rel, ws_root)
+        if candidate is None:
+            continue
         if candidate == resolved or candidate in resolved.parents:
             depth = len(candidate.parts)
             if depth > best_depth:
@@ -124,33 +157,57 @@ def build_status(start: Optional[Path] = None) -> dict:
 
     # shared_git_root state — where workspace memory commits land.
     sgr_rel = manifest.get("memory", {}).get("shared_git_root", ".")
-    sgr_path = (ws_root / sgr_rel).resolve() if sgr_rel != "." else ws_root
-    sgr_is_git = _is_git_worktree(sgr_path)
-    sgr_porcelain = (
-        _git_lines(["-C", str(sgr_path), "status", "--porcelain"])
-        if sgr_is_git else None
-    )
-    report["shared_git_root"] = {
-        "path": str(sgr_path),
-        "is_git_worktree": sgr_is_git,
-        "dirty": bool(sgr_porcelain) if sgr_porcelain is not None else None,
-    }
-    if not sgr_is_git:
-        warn("shared_git_root_not_git",
-             f"shared_git_root ({sgr_path}) is not a git worktree — "
-             f"workspace memory commits are unavailable until it is")
+    sgr_resolved = (ws_root if sgr_rel == "."
+                    else _contained(ws_root / sgr_rel, ws_root))
+    if sgr_resolved is None:
+        # Canonical escape (symlink out of the workspace): never probe git
+        # state on the foreign target.
+        report["shared_git_root"] = {
+            "path": str(ws_root / sgr_rel),
+            "is_git_worktree": False,
+            "dirty": None,
+        }
+        warn("shared_git_root_escapes_workspace",
+             f"shared_git_root ({sgr_rel}) resolves outside the workspace "
+             f"root — refusing to inspect it")
+        sgr_is_git = False
+    else:
+        sgr_is_git = _is_repo_root(sgr_resolved)
+        sgr_porcelain = (
+            _git_lines(["-C", str(sgr_resolved), "status", "--porcelain"])
+            if sgr_is_git else None
+        )
+        report["shared_git_root"] = {
+            "path": str(sgr_resolved),
+            "is_git_worktree": sgr_is_git,
+            "dirty": (bool(sgr_porcelain)
+                      if sgr_porcelain is not None else None),
+        }
+        if not sgr_is_git:
+            warn("shared_git_root_not_git",
+                 f"shared_git_root ({sgr_resolved}) is not the root of a "
+                 f"git worktree — workspace memory commits are unavailable "
+                 f"until it is")
 
     # Manifest trackedness — ratified convention: committed in shared_git_root.
-    if sgr_is_git:
+    if sgr_is_git and sgr_resolved is not None:
         rel_manifest = None
         try:
             rel_manifest = (ws_root / ".asha" / "workspace.json").resolve() \
-                .relative_to(sgr_path)
-        except ValueError:
+                .relative_to(sgr_resolved)
+        except (ValueError, OSError, RuntimeError):
             pass
-        if rel_manifest is not None:
+        if rel_manifest is None:
+            # A layout like shared_git_root="Memory" is valid, but the
+            # manifest then lives OUTSIDE the commit repo — the convention
+            # cannot apply, and silence would hide that (pass-2 finding).
+            warn("manifest_outside_shared_git_root",
+                 ".asha/workspace.json lies outside the shared_git_root "
+                 "tree — the committed-manifest convention cannot apply to "
+                 "this layout")
+        else:
             tracked = _git_lines(
-                ["-C", str(sgr_path), "ls-files", "--error-unmatch",
+                ["-C", str(sgr_resolved), "ls-files", "--error-unmatch",
                  str(rel_manifest)]
             )
             report["manifest_tracked"] = tracked is not None
@@ -159,7 +216,7 @@ def build_status(start: Optional[Path] = None) -> dict:
                      "the workspace manifest is not committed in "
                      "shared_git_root — the ratified convention is to track "
                      "it so the workspace definition is shared "
-                     f"(git -C {sgr_path} add {rel_manifest})")
+                     f"(git -C {sgr_resolved} add {rel_manifest})")
 
     # Declared repositories — reported, never assumed.
     start_path = Path(start if start is not None else Path.cwd())
@@ -168,7 +225,9 @@ def build_status(start: Optional[Path] = None) -> dict:
         rel = entry.get("path")
         if not isinstance(rel, str):
             continue
-        state = _repo_state(ws_root / rel)
+        lexical = ws_root / rel
+        resolved = _contained(lexical, ws_root)
+        state = _repo_state(lexical, resolved)
         state["path"] = rel
         if "role" in entry:
             state["role"] = entry["role"]
@@ -177,6 +236,10 @@ def build_status(start: Optional[Path] = None) -> dict:
             warn("repo_missing",
                  f"declared repository {rel} does not exist under the "
                  f"workspace root")
+        elif resolved is None:
+            warn("repo_escapes_workspace",
+                 f"declared repository {rel} resolves outside the workspace "
+                 f"root — refusing to inspect it")
         elif not state["is_git_worktree"]:
             warn("repo_not_git",
                  f"declared repository {rel} exists but is not a git "
@@ -193,6 +256,13 @@ def _render_human(report: dict) -> str:
     with contextlib.redirect_stdout(out):
         if report["workspace_root"] is None and not report["errors"]:
             print("workspace: none (single-project mode)")
+        elif report["workspace_root"] is None and report["errors"]:
+            # Detection itself failed (bad start dir, unreadable ancestor):
+            # there is no manifest to repair — misdirecting the user to edit
+            # one was a pass-2 finding.
+            print("workspace: detection failed")
+            for e in report["errors"]:
+                print(f"  error: {e['code']} — {e['message']}")
         elif not report["ok"]:
             print(f"workspace: INVALID at {report['workspace_root'] or '?'}")
             for e in report["errors"]:
@@ -200,8 +270,8 @@ def _render_human(report: dict) -> str:
                 print(f"  error: {e['code']}{field} — {e['message']}")
             print("  repair: edit .asha/workspace.json at the workspace "
                   "root, then validate with:")
-            print("    python3 plugins/session/tools/workspace_manifest.py "
-                  "<path-to-workspace.json>")
+            validator = Path(__file__).resolve().parent / "workspace_manifest.py"
+            print(f"    python3 {validator} <path-to-workspace.json>")
             print("  (fail-closed by design: no partial workspace behavior "
                   "until the manifest is valid)")
         else:
@@ -215,6 +285,11 @@ def _render_human(report: dict) -> str:
             if sgr.get("dirty") is not None:
                 dirty = ", dirty" if sgr["dirty"] else ", clean"
             print(f"  shared_git_root: {sgr.get('path')} ({state}{dirty})")
+            mem = report["memory"] or {}
+            print(f"  memory: operational={mem.get('operational_root')} "
+                  f"personal={mem.get('personal_root')} "
+                  f"shared={mem.get('shared_root')} "
+                  f"(promotion: {mem.get('promotion_mode')})")
             if report["manifest_tracked"] is not None:
                 print(f"  manifest tracked: "
                       f"{'yes' if report['manifest_tracked'] else 'NO'}")
@@ -242,11 +317,22 @@ def main(argv: List[str]) -> int:
     while i < len(args):
         if args[i] == "--json":
             as_json = True
-        elif args[i] == "--start" and i + 1 < len(args):
+        elif args[i] == "--start":
+            # The value must exist and must not be another flag — silently
+            # consuming "--json" as a directory was a pass-2 finding.
+            if i + 1 >= len(args) or args[i + 1].startswith("--"):
+                print("usage: workspace_status.py [--json] [--start DIR]",
+                      file=sys.stderr)
+                return 2
             start = Path(args[i + 1])
             i += 1
         elif args[i].startswith("--start="):
-            start = Path(args[i].split("=", 1)[1])
+            value = args[i].split("=", 1)[1]
+            if not value:
+                print("usage: workspace_status.py [--json] [--start DIR]",
+                      file=sys.stderr)
+                return 2
+            start = Path(value)
         else:
             print("usage: workspace_status.py [--json] [--start DIR]",
                   file=sys.stderr)

--- a/tests/python/test_workspace_status.py
+++ b/tests/python/test_workspace_status.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Tests for workspace_status (workspace v1, delivery issue 3 — issue #35).
+
+The first consumer of the detection primitive: enriches detect_workspace()
+with git state (active child repo, per-repo presence/branch/dirty,
+shared_git_root state, manifest trackedness) and renders human + --json
+views. Ratified convention (Keeper, 2026-08-08): the manifest is committed
+in shared_git_root — an untracked manifest is a WARNING; an invalid one is
+a typed error with guided repair, never auto-fix.
+"""
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import workspace_status as ws  # type: ignore[reportMissingImports]  # noqa: E402
+
+
+def _git(*args, cwd=None):
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True,
+        capture_output=True, text=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+class StatusFixture(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_wss_")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, True))
+        self._home = os.environ.get("HOME")
+        home = self.tmp / "home"
+        home.mkdir()
+        os.environ["HOME"] = str(home)
+        self.addCleanup(self._restore_home)
+        self.ws = home / "Code" / "thallus"
+        self.ws.mkdir(parents=True)
+
+    def _restore_home(self):
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+    def _manifest(self, data=None):
+        (self.ws / ".asha").mkdir(exist_ok=True)
+        payload = data if data is not None else {
+            "version": 1, "workspace_name": "thallus",
+            "repositories": [
+                {"path": "egregore", "role": "svc"},
+                {"path": "servitor", "role": "svc"},
+            ],
+        }
+        (self.ws / ".asha" / "workspace.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    def _init_workspace_git(self, track_manifest=True):
+        _git("init", "-q", str(self.ws))
+        (self.ws / "README.md").write_text("x", encoding="utf-8")
+        _git("add", "README.md", cwd=self.ws)
+        if track_manifest and (self.ws / ".asha" / "workspace.json").exists():
+            _git("add", ".asha/workspace.json", cwd=self.ws)
+        _git("commit", "-qm", "init", cwd=self.ws)
+
+    def _child(self, name, git=True):
+        child = self.ws / name
+        child.mkdir(exist_ok=True)
+        if git:
+            _git("init", "-q", str(child))
+            (child / "f").write_text("x", encoding="utf-8")
+            _git("add", "f", cwd=child)
+            _git("commit", "-qm", "init", cwd=child)
+        return child
+
+
+class NoWorkspaceCases(StatusFixture):
+    def test_no_workspace_is_ok_and_quiet(self):
+        lone = self.tmp / "home" / "solo"
+        lone.mkdir(parents=True)
+        report = ws.build_status(start=lone)
+        self.assertTrue(report["ok"])
+        self.assertIsNone(report["workspace_root"])
+        self.assertEqual(report["errors"], [])
+        self.assertEqual(report["warnings"], [])
+
+    def test_cli_no_workspace_exit_zero(self):
+        lone = self.tmp / "home" / "solo"
+        lone.mkdir(parents=True)
+        rc, out = _run_cli(["workspace_status.py", "--json",
+                            "--start", str(lone)])
+        self.assertEqual(rc, 0)
+        self.assertTrue(json.loads(out)["ok"])
+
+
+class ValidWorkspaceCases(StatusFixture):
+    def setUp(self):
+        super().setUp()
+        self._manifest()
+        self._init_workspace_git(track_manifest=True)
+        self.egregore = self._child("egregore", git=True)
+        # servitor is declared but ABSENT — must be reported, never assumed.
+
+    def test_report_shape(self):
+        report = ws.build_status(start=self.egregore)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["workspace_root"], str(self.ws))
+        self.assertEqual(report["workspace_name"], "thallus")
+        self.assertEqual(report["active_repository"], "egregore")
+        sgr = report["shared_git_root"]
+        self.assertEqual(sgr["path"], str(self.ws))
+        self.assertTrue(sgr["is_git_worktree"])
+        self.assertTrue(report["manifest_tracked"])
+
+    def test_declared_repo_states(self):
+        report = ws.build_status(start=self.egregore)
+        repos = {r["path"]: r for r in report["repositories"]}
+        self.assertTrue(repos["egregore"]["exists"])
+        self.assertTrue(repos["egregore"]["is_git_worktree"])
+        self.assertEqual(repos["egregore"]["branch"], "master")
+        self.assertFalse(repos["egregore"]["dirty"])
+        self.assertFalse(repos["servitor"]["exists"])
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("repo_missing", codes)
+
+    def test_dirty_child_reported(self):
+        (self.egregore / "new.txt").write_text("y", encoding="utf-8")
+        report = ws.build_status(start=self.egregore)
+        repos = {r["path"]: r for r in report["repositories"]}
+        self.assertTrue(repos["egregore"]["dirty"])
+
+    def test_active_repo_none_at_workspace_root(self):
+        report = ws.build_status(start=self.ws)
+        self.assertIsNone(report["active_repository"])
+
+    def test_untracked_manifest_warns_per_convention(self):
+        _git("rm", "-q", "--cached", ".asha/workspace.json", cwd=self.ws)
+        report = ws.build_status(start=self.egregore)
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("manifest_untracked", codes)
+        self.assertFalse(report["manifest_tracked"])
+        self.assertTrue(report["ok"], "a warning must not flip ok")
+
+    def test_cli_valid_exit_zero_json(self):
+        rc, out = _run_cli(["workspace_status.py", "--json",
+                            "--start", str(self.egregore)])
+        self.assertEqual(rc, 0)
+        report = json.loads(out)
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["active_repository"], "egregore")
+
+    def test_human_output_mentions_essentials(self):
+        rc, out = _run_cli(["workspace_status.py",
+                            "--start", str(self.egregore)])
+        self.assertEqual(rc, 0)
+        self.assertIn("thallus", out)
+        self.assertIn("egregore", out)
+        self.assertIn("servitor", out)
+
+
+class InvalidWorkspaceCases(StatusFixture):
+    def test_invalid_manifest_typed_errors_and_repair(self):
+        self._manifest({"version": 2, "workspace_name": "thallus"})
+        child = self._child("egregore", git=False)
+        report = ws.build_status(start=child)
+        self.assertFalse(report["ok"])
+        codes = {e["code"] for e in report["errors"]}
+        self.assertIn("unsupported_version", codes)
+
+    def test_cli_invalid_exit_one_with_repair_guidance(self):
+        self._manifest({"version": 2, "workspace_name": "thallus"})
+        child = self._child("egregore", git=False)
+        rc, out = _run_cli(["workspace_status.py", "--start", str(child)])
+        self.assertEqual(rc, 1)
+        # Guided repair, never auto-fix (ratified convention).
+        self.assertIn("repair", out.lower())
+        self.assertIn("workspace.json", out)
+
+    def test_shared_git_root_not_a_repo_warns(self):
+        self._manifest()
+        child = self._child("egregore", git=True)
+        # workspace root deliberately NOT a git repo: sgr invalid for commits
+        report = ws.build_status(start=child)
+        self.assertTrue(report["ok"])
+        self.assertFalse(report["shared_git_root"]["is_git_worktree"])
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("shared_git_root_not_git", codes)
+        self.assertIsNone(report["manifest_tracked"])
+
+
+def _run_cli(argv):
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = ws.main(argv)
+    return rc, out.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_workspace_status.py
+++ b/tests/python/test_workspace_status.py
@@ -28,7 +28,9 @@ import workspace_status as ws  # type: ignore[reportMissingImports]  # noqa: E40
 
 def _git(*args, cwd=None):
     subprocess.run(
-        ["git", *args], cwd=cwd, check=True,
+        # init.defaultBranch pinned: the branch assertions must not depend on
+        # the machine's git config (pass-2 portability finding).
+        ["git", "-c", "init.defaultBranch=master", *args], cwd=cwd, check=True,
         capture_output=True, text=True,
         env={**os.environ,
              "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
@@ -168,6 +170,62 @@ class ValidWorkspaceCases(StatusFixture):
         self.assertIn("thallus", out)
         self.assertIn("egregore", out)
         self.assertIn("servitor", out)
+        # The proposal's status surface includes the memory roots (pass-2
+        # blocking finding: they were omitted entirely).
+        self.assertIn("Memory", out)
+        self.assertIn("memory-local", out)
+        self.assertIn("knowledge", out)
+
+    def test_plain_subdirectory_is_not_a_repo(self):
+        # Pass-2 BLOCKING: a declared repo that is a plain subdir inside the
+        # PARENT repo must not inherit the parent's branch/dirty state —
+        # is-inside-work-tree is true anywhere under the workspace repo.
+        plain = self.ws / "plainchild"
+        plain.mkdir()
+        data = json.loads(
+            (self.ws / ".asha" / "workspace.json").read_text(encoding="utf-8")
+        )
+        data["repositories"].append({"path": "plainchild"})
+        self._manifest(data)
+        report = ws.build_status(start=self.egregore)
+        repos = {r["path"]: r for r in report["repositories"]}
+        self.assertTrue(repos["plainchild"]["exists"])
+        self.assertFalse(repos["plainchild"]["is_git_worktree"])
+        self.assertIsNone(repos["plainchild"]["branch"])
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("repo_not_git", codes)
+
+    def test_symlinked_repo_escaping_workspace_is_flagged_not_probed(self):
+        # Pass-2 BLOCKING: a declared path that resolves outside the
+        # workspace must not have git state read from the foreign target.
+        outside = self.tmp / "elsewhere"
+        outside.mkdir()
+        _git("init", "-q", str(outside))
+        (self.ws / "escapee").symlink_to(outside)
+        data = json.loads(
+            (self.ws / ".asha" / "workspace.json").read_text(encoding="utf-8")
+        )
+        data["repositories"].append({"path": "escapee"})
+        self._manifest(data)
+        report = ws.build_status(start=self.egregore)
+        repos = {r["path"]: r for r in report["repositories"]}
+        self.assertFalse(repos["escapee"]["is_git_worktree"])
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("repo_escapes_workspace", codes)
+        self.assertNotEqual(report["active_repository"], "escapee")
+
+    def test_unborn_repo_still_reports_branch(self):
+        unborn = self.ws / "fresh"
+        unborn.mkdir()
+        _git("init", "-q", str(unborn))
+        data = json.loads(
+            (self.ws / ".asha" / "workspace.json").read_text(encoding="utf-8")
+        )
+        data["repositories"].append({"path": "fresh"})
+        self._manifest(data)
+        report = ws.build_status(start=self.egregore)
+        repos = {r["path"]: r for r in report["repositories"]}
+        self.assertEqual(repos["fresh"]["branch"], "master")
 
 
 class InvalidWorkspaceCases(StatusFixture):
@@ -187,6 +245,52 @@ class InvalidWorkspaceCases(StatusFixture):
         # Guided repair, never auto-fix (ratified convention).
         self.assertIn("repair", out.lower())
         self.assertIn("workspace.json", out)
+
+    def test_manifest_outside_shared_git_root_warns(self):
+        # Pass-2 BLOCKING: sgr="Memory" is a VALID layout (op == sgr), but
+        # the workspace manifest then lies outside the sgr tree — the
+        # committed-manifest convention cannot apply, and that must be a
+        # visible warning, not a silent null.
+        self._manifest({
+            "version": 1, "workspace_name": "thallus",
+            "memory": {"shared_git_root": "Memory",
+                       "operational_root": "Memory"},
+        })
+        mem = self.ws / "Memory"
+        mem.mkdir(exist_ok=True)
+        _git("init", "-q", str(mem))
+        (mem / "seed").write_text("x", encoding="utf-8")
+        _git("add", "seed", cwd=mem)
+        _git("commit", "-qm", "init", cwd=mem)
+        child = self._child("egregore", git=False)
+        report = ws.build_status(start=child)
+        self.assertTrue(report["ok"])
+        self.assertIsNone(report["manifest_tracked"])
+        codes = {w["code"] for w in report["warnings"]}
+        self.assertIn("manifest_outside_shared_git_root", codes)
+
+    def test_detection_failure_renders_without_manifest_repair(self):
+        # Pass-2: a bad --start is a DETECTION failure; telling the user to
+        # repair a manifest that was never found is misdirection.
+        rc, out = _run_cli(["workspace_status.py",
+                            "--start", str(self.tmp / "nope")])
+        self.assertEqual(rc, 1)
+        self.assertNotIn("repair: edit", out)
+        self.assertIn("detection", out.lower())
+
+    def test_repair_guidance_uses_absolute_tool_path(self):
+        self._manifest({"version": 2, "workspace_name": "thallus"})
+        child = self._child("egregore", git=False)
+        rc, out = _run_cli(["workspace_status.py", "--start", str(child)])
+        self.assertEqual(rc, 1)
+        self.assertIn(str(TOOLS_DIR / "workspace_manifest.py"), out)
+
+    def test_cli_usage_errors(self):
+        for argv in (["workspace_status.py", "--start="],
+                     ["workspace_status.py", "--start", "--json"],
+                     ["workspace_status.py", "--start"]):
+            rc, _ = _run_cli(argv)
+            self.assertEqual(rc, 2, argv)
 
     def test_shared_git_root_not_a_repo_warns(self):
         self._manifest()

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -225,6 +225,17 @@ else
 fi
 echo ""
 
+# Test Suite 15: Workspace Status Tests (workspace v1, issue #35)
+echo -e "${BLUE}--- Test Suite 15: Workspace Status Tests ---${NC}"
+if "$SCRIPT_DIR/test-workspace.sh"; then
+    echo -e "${GREEN}✓ Workspace status tests passed${NC}"
+    TOTAL_PASSED=$((TOTAL_PASSED + 1))
+else
+    echo -e "${RED}✗ Workspace status tests failed${NC}"
+    TOTAL_FAILED=$((TOTAL_FAILED + 1))
+fi
+echo ""
+
 # Summary
 echo -e "${BLUE}=== Test Summary ===${NC}"
 echo -e "Passed:  ${GREEN}$TOTAL_PASSED${NC}"

--- a/tests/test-workspace.sh
+++ b/tests/test-workspace.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-workspace.sh — `asha workspace status` dispatcher + doctor section
+# (workspace v1, delivery issue 3 — issue #35).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+
+pass() { echo -e "${GREEN}PASS${NC}"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}FAIL${NC}"; echo "  $1"; FAILED=$((FAILED + 1)); }
+
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+export HOME="$FIX/home"   # sandbox: the walk stops before $HOME (exclusive)
+mkdir -p "$HOME"
+
+git_q() { git -c user.name=t -c user.email=t@t "$@" >/dev/null 2>&1; }
+
+# Fixture: a valid workspace with one present child repo and one declared-
+# but-missing repo; manifest committed in shared_git_root (the convention).
+WS="$HOME/Code/thallus"
+mkdir -p "$WS/.asha" "$WS/egregore"
+cat > "$WS/.asha/workspace.json" <<'EOF'
+{
+  "version": 1,
+  "workspace_name": "thallus",
+  "repositories": [
+    {"path": "egregore", "role": "svc"},
+    {"path": "servitor", "role": "svc"}
+  ]
+}
+EOF
+git_q init "$WS"
+( cd "$WS" && echo x > README.md && git_q add README.md .asha/workspace.json && git_q commit -m init )
+git_q init "$WS/egregore"
+( cd "$WS/egregore" && echo x > f && git_q add f && git_q commit -m init )
+
+# Fixture: an invalid workspace.
+BAD="$HOME/Code/badws"
+mkdir -p "$BAD/.asha" "$BAD/child"
+printf '{"version": 2, "workspace_name": "bad"}' > "$BAD/.asha/workspace.json"
+
+# Fixture: no workspace at all.
+LONE="$HOME/Code/solo"
+mkdir -p "$LONE"
+
+ASHA="$REPO_ROOT/bin/asha"
+
+echo -n "Test WS-1: no workspace -> exit 0, single-project line... "
+out="$("$ASHA" workspace status --start "$LONE" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 && "$out" == *"workspace: none"* ]]; then pass; else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-2: valid workspace -> exit 0, essentials present... "
+out="$("$ASHA" workspace status --start "$WS/egregore" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 && "$out" == *"thallus"* && "$out" == *"egregore"* \
+      && "$out" == *"servitor"* && "$out" == *"repo_missing"* ]]; then
+    pass
+else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-3: --json parses; active repo + tracked manifest... "
+out="$("$ASHA" workspace status --json --start "$WS/egregore" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 ]] \
+   && [[ "$(printf '%s' "$out" | jq -r '.ok')" == "true" ]] \
+   && [[ "$(printf '%s' "$out" | jq -r '.active_repository')" == "egregore" ]] \
+   && [[ "$(printf '%s' "$out" | jq -r '.manifest_tracked')" == "true" ]]; then
+    pass
+else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-4: untracked manifest warns per convention... "
+( cd "$WS" && git_q rm --cached .asha/workspace.json )
+out="$("$ASHA" workspace status --json --start "$WS/egregore" 2>&1)" && rc=0 || rc=$?
+codes="$(printf '%s' "$out" | jq -r '.warnings[].code' 2>/dev/null || true)"
+( cd "$WS" && git_q add .asha/workspace.json )   # restore for later tests
+if [[ $rc -eq 0 && "$codes" == *"manifest_untracked"* ]]; then pass; else fail "rc=$rc codes=$codes"; fi
+
+echo -n "Test WS-5: invalid manifest -> exit 1 with guided repair... "
+out="$("$ASHA" workspace status --start "$BAD/child" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 1 && "$out" == *"repair"* && "$out" == *"workspace.json"* \
+      && "$out" == *"unsupported_version"* ]]; then
+    pass
+else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-6: unknown subcommand -> usage error 2... "
+"$ASHA" workspace bogus >/dev/null 2>&1 && rc=0 || rc=$?
+if [[ $rc -eq 2 ]]; then pass; else fail "rc=$rc"; fi
+
+echo -n "Test WS-7: bare 'asha workspace' -> usage error 2... "
+"$ASHA" workspace >/dev/null 2>&1 && rc=0 || rc=$?
+if [[ $rc -eq 2 ]]; then pass; else fail "rc=$rc"; fi
+
+echo -n "Test WS-8: doctor section silent pass outside workspaces... "
+out="$(cd "$LONE" && MARKET_ROOT="$REPO_ROOT" bash -c "
+    source '$REPO_ROOT/lib/doctor.sh'; _asha_doctor_workspace_section" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 && -z "$out" ]]; then pass; else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-9: doctor section fails closed on invalid workspace... "
+out="$(cd "$BAD/child" && MARKET_ROOT="$REPO_ROOT" bash -c "
+    source '$REPO_ROOT/lib/doctor.sh'; _asha_doctor_workspace_section" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 1 && "$out" == *"Workspace"* && "$out" == *"repair"* ]]; then
+    pass
+else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-10: doctor section reports valid workspace, rc 0... "
+out="$(cd "$WS/egregore" && MARKET_ROOT="$REPO_ROOT" bash -c "
+    source '$REPO_ROOT/lib/doctor.sh'; _asha_doctor_workspace_section" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 && "$out" == *"thallus"* ]]; then pass; else fail "rc=$rc out=$out"; fi
+
+echo ""
+echo -e "Passed: ${GREEN}${PASSED}${NC}  Failed: ${RED}${FAILED}${NC}"
+[[ $FAILED -eq 0 ]]

--- a/tests/test-workspace.sh
+++ b/tests/test-workspace.sh
@@ -20,7 +20,7 @@ trap 'rm -rf "$FIX"' EXIT
 export HOME="$FIX/home"   # sandbox: the walk stops before $HOME (exclusive)
 mkdir -p "$HOME"
 
-git_q() { git -c user.name=t -c user.email=t@t "$@" >/dev/null 2>&1; }
+git_q() { git -c user.name=t -c user.email=t@t -c init.defaultBranch=master "$@" >/dev/null 2>&1; }
 
 # Fixture: a valid workspace with one present child repo and one declared-
 # but-missing repo; manifest committed in shared_git_root (the convention).
@@ -59,7 +59,9 @@ if [[ $rc -eq 0 && "$out" == *"workspace: none"* ]]; then pass; else fail "rc=$r
 echo -n "Test WS-2: valid workspace -> exit 0, essentials present... "
 out="$("$ASHA" workspace status --start "$WS/egregore" 2>&1)" && rc=0 || rc=$?
 if [[ $rc -eq 0 && "$out" == *"thallus"* && "$out" == *"egregore"* \
-      && "$out" == *"servitor"* && "$out" == *"repo_missing"* ]]; then
+      && "$out" == *"servitor"* && "$out" == *"repo_missing"* \
+      && "$out" == *"operational=Memory"* \
+      && "$out" == *"memory-local"* && "$out" == *"knowledge"* ]]; then
     pass
 else fail "rc=$rc out=$out"; fi
 
@@ -110,6 +112,14 @@ echo -n "Test WS-10: doctor section reports valid workspace, rc 0... "
 out="$(cd "$WS/egregore" && MARKET_ROOT="$REPO_ROOT" bash -c "
     source '$REPO_ROOT/lib/doctor.sh'; _asha_doctor_workspace_section" 2>&1)" && rc=0 || rc=$?
 if [[ $rc -eq 0 && "$out" == *"thallus"* ]]; then pass; else fail "rc=$rc out=$out"; fi
+
+echo -n "Test WS-11: doctor section visibly skips without python3... "
+out="$(cd "$WS/egregore" && MARKET_ROOT="$REPO_ROOT" bash -c "
+    source '$REPO_ROOT/lib/doctor.sh'; PATH=/nonexistent
+    _asha_doctor_workspace_section" 2>&1)" && rc=0 || rc=$?
+if [[ $rc -eq 0 && "$out" == *"skipped"* && "$out" == *"python3"* ]]; then
+    pass
+else fail "rc=$rc out=$out"; fi
 
 echo ""
 echo -e "Passed: ${GREEN}${PASSED}${NC}  Failed: ${RED}${FAILED}${NC}"


### PR DESCRIPTION
Closes #35. First consumer of the detection primitive (PR #34) — the workspace feature becomes user-visible with this PR.

## What changed

- **`plugins/session/tools/workspace_status.py`** (new) — enriches `detect_workspace()` with read-only git state: active child repository (deepest declared repo containing cwd; cwd-only per the ratified proposal), per-repo presence/branch/dirty (**reported, never assumed**), `shared_git_root` health, manifest trackedness. Never raises — git failures degrade to typed nulls. Exit: 0 no-workspace/valid (warnings never flip it), 1 invalid manifest, 2 usage.
- **`asha workspace status [--json] [--start DIR]`** — new dispatcher verb via a thin `lib/workspace.sh` shim. No new fallback chain: detection stays with the shared resolver (the PR #34 audit invariant holds). No bootstrap symlink-walk copy — this engine is sourced only by `bin/asha`.
- **`asha doctor`** gains a workspace section: silent outside workspaces, prints the report inside one, **fails doctor on an invalid manifest** (fail-closed: a broken workspace definition is install-grade). Fixed a latent rc-capture issue: drift-check ran as the last command under `set -e`, so a bare non-zero would have skipped anything appended after it.
- **Ratified decision recorded in the proposal doc** (precedence rule — doc first): open question 1 **RESOLVED** — the manifest is committed in `shared_git_root` by convention; `status`/doctor warn when untracked (`manifest_untracked`); invalid manifests print guided repair steps, never an auto-fix.

## Test plan

- [x] 12 python unit tests (RED before the tool existed): report shape, repo states incl. declared-but-missing, dirty detection, active-repo resolution, untracked-manifest warning, invalid-manifest repair guidance, sgr-not-git warning, CLI exit contract
- [x] New Suite 15 (`tests/test-workspace.sh`, 10 cases): dispatcher wiring, --json via jq, usage errors, doctor section silent/fail-closed/reporting
- [x] Full suite **14/14**; `validate-versions` green (session 1.16.0)
- [ ] Codex adversarial pass before leaving draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)