### PR TITLE
feat: save scopes + state-based commit gate (workspace v1, delivery issue 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This guide helps AI assistants (like Claude) understand the asha codebase struct
 
 | Plugin | Version | Domain | Description |
 |--------|---------|--------|-------------|
-| **Session** | v1.16.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Session** | v1.17.0 | Core | Memory persistence, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Asha** | v2.1.0 | Identity | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Panel System** | v5.0.0 | Research | Multi-perspective analysis with persistence and resumption — 6 agents |
 | **Code** | v1.5.0 | Development | Code review, orchestration patterns, TDD, issue-to-merge loop — 5 agents, postgres skill |
@@ -919,6 +919,16 @@ git push -u origin <branch-name>
 ---
 
 ## Version History
+
+### Session v1.17.0 (2026-08-08) — save scopes + state-based commit gate
+
+Workspace v1 delivery issue 4 (issue #36). `/save --scope repo|workspace|
+none`; `save_scope.py` writer seam (plane mapping as three distinct values,
+versioned proof, verify-before-commit); commit gate selects planes by
+staged STATE, never command parsing — bash existence walk keeps no-manifest
+byte-identity at zero python cost (golden corpus), manifest-present-but-
+unvalidatable fails closed, ambiguity denies, proofs are plane-bound. Stop
+hook routes v2 locators to the structural proof. Tests-first throughout.
 
 ### Session v1.16.0 (2026-08-08) — `asha workspace status` + doctor section
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ They form a pipeline, not an overlap: guardrails read session_state for in-fligh
 
 | Domain | Plugin | Version | Purpose |
 |--------|--------|---------|---------|
-| **Core** | `session` | v1.16.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
+| **Core** | `session` | v1.17.0 | Session memory, `/save` synthesis, `/consolidate` compaction, guardrail + guidance-nudge hooks, autonomous loops |
 | **Identity** | `asha` | v2.1.0 | Persona templates (`soul.md`, `voice.md`) consumed by `/session:init` |
 | **Research** | `panel-system` | v5.0.0 | Multi-perspective analysis, expert panels, decision-making — 6 agents |
 | **Development** | `code` | v1.5.0 | Code review, orchestration patterns, TDD, overnight issue-to-merge loop — 5 agents |
@@ -335,7 +335,7 @@ Create a ComfyUI workflow for: txt2img with upscaling
 
 **Plugin Name**: `session`
 **Commands**: `/session:init`, `/session:save`, `/session:status`, `/session:silence`, `/session:restore`, `/session:loop`
-**Version**: 1.16.0
+**Version**: 1.17.0
 **Domain**: Core
 
 Session coordination and memory persistence — the foundation layer other plugins build on. Learnings persist as an OKF concept bundle (`~/.asha/learnings/`, one file per learning) with auto-suggested `## Related` cross-links at `/save`; see [`docs/memory-architecture.md`](docs/memory-architecture.md).
@@ -563,6 +563,23 @@ Individual plugins licensed separately. See each plugin's LICENSE file (MIT thro
 ---
 
 ## Version History
+
+### Session v1.17.0 — save scopes + state-based commit gate (2026-08-08)
+
+Workspace v1 delivery issue 4 (issue #36), design ratified via adversarial
+consult. `/save` gains `--scope repo|workspace|none`; the writer-side seam
+(`tools/save_scope.py`) resolves a scope into its plane mapping —
+`plane_base` / `memory_root` / `commit_repo` as three distinct values —
+writes a **versioned structured proof** at the plane, and verifies it
+immediately before commit. `save-commit-gate.sh` becomes plane-aware by
+**repository state, never command parsing** (a spoofed `-C` is irrelevant
+when staged sets decide): a pure-bash existence walk keeps the no-manifest
+path byte-identical at zero python cost (12-case golden corpus pins it);
+manifest-present-but-unvalidatable **fails closed**; both-planes-staged
+denies as ambiguous; each plane's proof satisfies only itself. The
+Stop-hook net routes v2 locators to the plane's structural proof (the
+session-transcript gates stay project-scoped by design). 17 save_scope
+unit tests + Test 9c (19 gate pins), tests-first.
 
 ### Session v1.16.0 + `asha workspace status` — first workspace consumer (2026-08-08)
 

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -1,6 +1,6 @@
 # Session
 
-**Version**: 1.16.0
+**Version**: 1.17.0
 
 Session management with memory persistence, pattern extraction, and operational quality.
 

--- a/plugins/session/commands/save.md
+++ b/plugins/session/commands/save.md
@@ -1,7 +1,7 @@
 ---
 name: session-save
 description: "Manually trigger session synthesis and git commit"
-argument-hint: "[--no-push] [commit message]"
+argument-hint: "[--scope repo|workspace|none] [--no-push] [commit message]"
 allowed-tools: ["Bash", "Read", "Edit"]
 ---
 
@@ -30,7 +30,54 @@ currently require this explicit command because Asha has no SessionEnd hook ther
 /save                           # Synthesize + commit + push
 /save --no-push                 # Synthesize + commit only
 /save "Completed auth feature"  # Custom commit message
+/save --scope workspace         # Commit the WORKSPACE memory plane (see below)
+/save --scope none              # Synthesis only: no staging, commit, or push
 ```
+
+## Save scopes (workspace v1, issue #36)
+
+Bare `/save` (or `--scope repo`) is the project save documented below —
+inside a workspace that is the active CHILD repository, which is exactly
+today's behavior. Passing `--scope` in a project with NO workspace manifest
+is a hard error (the single carved-out deviation from byte-identical, pinned
+in the ratified proposal).
+
+**`--scope none`**: run the preflight report and synthesis steps below, then
+STOP — no queue drain, no staging, no commit, no push, no `save-pending`
+marker.
+
+**`--scope workspace`**: commits the workspace operational plane instead of
+the project. The plane's content is authored (v1 does not synthesize
+workspace memory); this flow routes ONLY the staging/commit/push, through
+the plane mapping and proof — never stage child-repo paths into it:
+
+```bash
+TOOLS="$ASHA_ROOT/plugins/session/tools"
+MAPPING="$(python3 "$TOOLS/save_scope.py" resolve --scope workspace)" || { echo "$MAPPING"; exit 1; }
+COMMIT_REPO="$(printf '%s' "$MAPPING" | jq -r .commit_repo)"
+MEM_ROOT="$(printf '%s' "$MAPPING" | jq -r .memory_root)"
+PLANE_BASE="$(printf '%s' "$MAPPING" | jq -r .plane_base)"
+REL_MEM="${MEM_ROOT#"$COMMIT_REPO"/}"
+
+python3 "$TOOLS/save_scope.py" write-proof --scope workspace
+python3 "$TOOLS/save_scope.py" verify --scope workspace || exit 1
+
+# Arm the Stop-hook net with a v2 locator carrying the plane (at the CHILD
+# project root, where the Stop hook looks; routing fields are load-bearing).
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+mkdir -p "$PROJECT_DIR/Work/markers"
+jq -n --arg c "$(date -u +%FT%TZ)" --arg p "$PLANE_BASE" \
+    '{created:$c, attempts:0, scope:"workspace", plane_base:$p}' \
+    > "$PROJECT_DIR/Work/markers/save-pending"
+
+git -C "$COMMIT_REPO" add "$REL_MEM/"
+git -C "$COMMIT_REPO" commit -m "Workspace save: ${ARGUMENTS:-checkpoint}"
+"$TOOLS/push_retry.py" ensure --project-dir "$COMMIT_REPO"   # unless --no-push
+```
+
+Then STOP — the project-scope pipeline below does not run for a workspace
+save. If any step fails, report the failure verbatim; never fall through to
+the project flow.
 
 ## Execution
 

--- a/plugins/session/commands/save.md
+++ b/plugins/session/commands/save.md
@@ -55,9 +55,8 @@ the plane mapping and proof — never stage child-repo paths into it:
 TOOLS="$ASHA_ROOT/plugins/session/tools"
 MAPPING="$(python3 "$TOOLS/save_scope.py" resolve --scope workspace)" || { echo "$MAPPING"; exit 1; }
 COMMIT_REPO="$(printf '%s' "$MAPPING" | jq -r .commit_repo)"
-MEM_ROOT="$(printf '%s' "$MAPPING" | jq -r .memory_root)"
 PLANE_BASE="$(printf '%s' "$MAPPING" | jq -r .plane_base)"
-REL_MEM="${MEM_ROOT#"$COMMIT_REPO"/}"
+REL_MEM="$(printf '%s' "$MAPPING" | jq -r .memory_rel)"   # "" = whole repo
 
 python3 "$TOOLS/save_scope.py" write-proof --scope workspace
 python3 "$TOOLS/save_scope.py" verify --scope workspace || exit 1
@@ -70,8 +69,10 @@ jq -n --arg c "$(date -u +%FT%TZ)" --arg p "$PLANE_BASE" \
     '{created:$c, attempts:0, scope:"workspace", plane_base:$p}' \
     > "$PROJECT_DIR/Work/markers/save-pending"
 
-git -C "$COMMIT_REPO" add "$REL_MEM/"
+git -C "$COMMIT_REPO" add "${REL_MEM:-.}/"
 git -C "$COMMIT_REPO" commit -m "Workspace save: ${ARGUMENTS:-checkpoint}"
+# The gate CONSUMES the proof on this commit (one proof = one commit); a
+# failed commit needs a fresh write-proof before retrying.
 "$TOOLS/push_retry.py" ensure --project-dir "$COMMIT_REPO"   # unless --no-push
 ```
 

--- a/plugins/session/hooks/handlers/save-commit-gate.sh
+++ b/plugins/session/hooks/handlers/save-commit-gate.sh
@@ -39,60 +39,177 @@ CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)"
 PROJECT_DIR="${CWD:-${CLAUDE_PROJECT_DIR:-$(pwd)}}"
 [[ -d "$PROJECT_DIR" ]] || exit 0
 
-# Does this commit touch Memory/? Two signals, either suffices:
-#   (a) the command itself references Memory/ (e.g. `git add Memory/ && git commit`)
-#   (b) the staged set already contains Memory/ paths (add ran in a prior block)
-#
 # Signal (a) inspects ONLY the portion of the command before the `commit`
 # subcommand. A commit MESSAGE that merely mentions Memory/ — as every commit
 # describing this very gate does — is not a staging operation and must never
 # trigger; grepping the whole command string (message included) is friendly
 # fire. `git add Memory/ && git commit …` still matches: the add precedes the
 # commit token.
-TOUCHES_MEMORY=0
 CMD_HEAD="${CMD%%commit*}"
-printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && TOUCHES_MEMORY=1
-if [[ $TOUCHES_MEMORY -eq 0 ]]; then
-    if git -C "$PROJECT_DIR" diff --cached --name-only 2>/dev/null | grep -q '^Memory/'; then
-        TOUCHES_MEMORY=1
+
+# gate_check_plane DIR — the original single-plane gate, byte-for-byte (Test
+# 9c golden corpus pins it). Used for the no-workspace path AND for the child
+# plane under a workspace.
+gate_check_plane() {
+    local dir="$1"
+    # Does this commit touch Memory/? Two signals, either suffices:
+    #   (a) the command head references Memory/
+    #   (b) the staged set already contains Memory/ paths
+    local touches=0
+    printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && touches=1
+    if [[ $touches -eq 0 ]]; then
+        if git -C "$dir" diff --cached --name-only 2>/dev/null | grep -q '^Memory/'; then
+            touches=1
+        fi
+    fi
+    [[ $touches -eq 1 ]] || return 0
+
+    # Nothing to gate before the project has an activeContext (e.g.
+    # /session:init's very first Memory commit).
+    local ac_file="$dir/Memory/activeContext.md"
+    [[ -f "$ac_file" ]] || return 0
+
+    # Silence marker: Memory persistence is disabled — a Memory commit under
+    # silence is a policy violation regardless of gates.
+    if [[ -f "$dir/Work/markers/silence" ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Memory/ commit refused: Work/markers/silence is active (Memory persistence disabled). Run /session:restore first." \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        return $?
+    fi
+
+    local marker="$dir/Work/markers/save-gates-ok"
+    local remedy="Run: \"\$ASHA_ROOT/plugins/session/tools/save-preflight-env.sh\" — it resolves the environment, verifies the save plugin, checks Memory notes against disk, and opens this gate only when all continuity gates pass."
+
+    if [[ ! -f "$marker" ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Memory/ commit refused: save preflight gates have not passed (no Work/markers/save-gates-ok). $remedy" \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        return $?
+    fi
+
+    local marker_sha disk_sha
+    marker_sha="$(jq -r '.ac_sha256 // empty' "$marker" 2>/dev/null || true)"
+    disk_sha="$(sha256sum "$ac_file" 2>/dev/null | cut -d' ' -f1 || true)"
+    if [[ -z "$marker_sha" || -z "$disk_sha" || "$marker_sha" != "$disk_sha" ]]; then
+        rm -f "$marker" 2>/dev/null || true
+        pretooluse_policy_deny "save-commit-gate" \
+            "Memory/ commit refused: activeContext.md changed AFTER the gates passed (marker hash ${marker_sha:0:12}… != disk ${disk_sha:0:12}…) — gates are stale. $remedy" \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        return $?
+    fi
+
+    # Gates passed against exactly this activeContext — allow the commit. The
+    # marker is left in place for the turn; the Stop-hook net still runs after.
+    return 0
+}
+
+# ---- plane routing (workspace v1, issue #36 — state-based, never parsed) ----
+# A pure-bash EXISTENCE walk decides legacy-vs-workspace: no python on the
+# hot path for non-workspace users, byte-identical legacy behavior (golden
+# corpus). When a manifest EXISTS, validation is mandatory and a broken
+# resolver DENIES — a manifest-present machine silently falling back to
+# child-only gating is exactly the bypass the design memo forbids.
+WS_MANIFEST=""
+LIB="$SELF_DIR/../../tools/project-root.sh"
+if [[ -f "$LIB" ]]; then
+    # shellcheck disable=SC1090
+    source "$LIB" 2>/dev/null || true
+    if declare -F asha_find_workspace_manifest >/dev/null 2>&1; then
+        WS_MANIFEST="$(asha_find_workspace_manifest "$PROJECT_DIR")"
     fi
 fi
-[[ $TOUCHES_MEMORY -eq 1 ]] || exit 0
 
-# Nothing to gate before the project has an activeContext (e.g. /session:init's
-# very first Memory commit).
-AC_FILE="$PROJECT_DIR/Memory/activeContext.md"
-[[ -f "$AC_FILE" ]] || exit 0
+if [[ -z "$WS_MANIFEST" ]]; then
+    gate_check_plane "$PROJECT_DIR"
+    exit $?
+fi
 
-# Silence marker: Memory persistence is disabled — a Memory commit under
-# silence is a policy violation regardless of gates.
-if [[ -f "$PROJECT_DIR/Work/markers/silence" ]]; then
+# Workspace branch. Candidate planes are selected by REPOSITORY STATE (what
+# is actually staged where), never by parsing -C out of the command — a
+# spoofed flag is irrelevant when state decides (design memo, PR #30 lesson).
+SS_TOOL="$SELF_DIR/../../tools/save_scope.py"
+MAPPING=""
+if command -v python3 >/dev/null 2>&1 && [[ -f "$SS_TOOL" ]]; then
+    MAPPING="$(python3 "$SS_TOOL" resolve --scope workspace --start "$PROJECT_DIR" 2>/dev/null)" || MAPPING=""
+fi
+PLANE_BASE="$(printf '%s' "$MAPPING" | jq -r '.plane_base // empty' 2>/dev/null || true)"
+COMMIT_REPO="$(printf '%s' "$MAPPING" | jq -r '.commit_repo // empty' 2>/dev/null || true)"
+MEM_ROOT="$(printf '%s' "$MAPPING" | jq -r '.memory_root // empty' 2>/dev/null || true)"
+
+CHILD_TOP="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+HEAD_REF=0
+printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && HEAD_REF=1
+
+if [[ -z "$PLANE_BASE" || -z "$COMMIT_REPO" || -z "$MEM_ROOT" ]]; then
+    # Manifest present but not validatable (invalid manifest, or
+    # python3/save_scope missing). Fail closed for anything with a visible
+    # Memory signal; a commit with no Memory signal anywhere stays allowed.
+    STAGED_ANY=0
+    [[ -n "$CHILD_TOP" ]] \
+        && git -C "$CHILD_TOP" diff --cached --name-only 2>/dev/null | grep -q '^Memory/' \
+        && STAGED_ANY=1
+    if [[ $HEAD_REF -eq 1 || $STAGED_ANY -eq 1 ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Memory/ commit refused: a workspace manifest exists at ${WS_MANIFEST%/.asha/workspace.json} but cannot be validated (invalid manifest, or python3/save_scope.py unavailable) — failing closed. Check: asha workspace status" \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        exit $?
+    fi
+    exit 0
+fi
+
+REL_MEM="${MEM_ROOT#"$COMMIT_REPO"/}"
+STAGED_WS=0
+git -C "$COMMIT_REPO" diff --cached --name-only 2>/dev/null | grep -q "^$REL_MEM/" && STAGED_WS=1
+STAGED_CHILD=0
+if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]]; then
+    git -C "$CHILD_TOP" diff --cached --name-only 2>/dev/null | grep -q '^Memory/' && STAGED_CHILD=1
+fi
+
+# A bare Memory/ reference in the command head attributes to the payload-cwd
+# repo (the default git target). A compound that -C's into ANOTHER repo is
+# deliberately not parsed; if its plane lacks staged state now, its own
+# commit-stage state check or proof requirement catches it — conservative,
+# never permissive.
+CAND_CHILD=$STAGED_CHILD
+CAND_WS=$STAGED_WS
+if [[ $HEAD_REF -eq 1 ]]; then
+    if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]]; then
+        CAND_CHILD=1
+    else
+        CAND_WS=1
+    fi
+fi
+
+if [[ $CAND_CHILD -eq 1 && $CAND_WS -eq 1 ]]; then
     pretooluse_policy_deny "save-commit-gate" \
-        "Memory/ commit refused: Work/markers/silence is active (Memory persistence disabled). Run /session:restore first." \
+        "Memory/ commit refused: BOTH the child repository and the workspace plane have Memory changes in flight — one commit cannot be proven for two planes. Commit them separately (child: /session:save; workspace: /session:save --scope workspace)." \
         " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
     exit $?
 fi
 
-MARKER="$PROJECT_DIR/Work/markers/save-gates-ok"
-REMEDY="Run: \"\$ASHA_ROOT/plugins/session/tools/save-preflight-env.sh\" — it resolves the environment, verifies the save plugin, checks Memory notes against disk, and opens this gate only when all continuity gates pass."
-
-if [[ ! -f "$MARKER" ]]; then
-    pretooluse_policy_deny "save-commit-gate" \
-        "Memory/ commit refused: save preflight gates have not passed (no Work/markers/save-gates-ok). $REMEDY" \
-        " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+if [[ $CAND_CHILD -eq 1 ]]; then
+    gate_check_plane "$CHILD_TOP"
     exit $?
 fi
 
-MARKER_SHA="$(jq -r '.ac_sha256 // empty' "$MARKER" 2>/dev/null || true)"
-DISK_SHA="$(sha256sum "$AC_FILE" 2>/dev/null | cut -d' ' -f1 || true)"
-if [[ -z "$MARKER_SHA" || -z "$DISK_SHA" || "$MARKER_SHA" != "$DISK_SHA" ]]; then
-    rm -f "$MARKER" 2>/dev/null || true
-    pretooluse_policy_deny "save-commit-gate" \
-        "Memory/ commit refused: activeContext.md changed AFTER the gates passed (marker hash ${MARKER_SHA:0:12}… != disk ${DISK_SHA:0:12}…) — gates are stale. $REMEDY" \
-        " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
-    exit $?
+if [[ $CAND_WS -eq 1 ]]; then
+    if [[ -f "$PLANE_BASE/Work/markers/silence" ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Workspace Memory commit refused: the workspace's Work/markers/silence is active." \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        exit $?
+    fi
+    # First-init exception, same as the single-plane gate.
+    [[ -f "$MEM_ROOT/activeContext.md" ]] || exit 0
+    WS_REASON="$(python3 "$SS_TOOL" verify --scope workspace --start "$PROJECT_DIR" 2>/dev/null)" && WS_OK=0 || WS_OK=$?
+    if [[ $WS_OK -ne 0 ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Workspace Memory commit refused: ${WS_REASON:-no valid workspace save proof}. Run /session:save --scope workspace (it writes the proof via save_scope.py before committing)." \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        exit $?
+    fi
+    exit 0
 fi
 
-# Gates passed against exactly this activeContext — allow the commit. The
-# marker is left in place for the turn; the Stop-hook net still runs after.
 exit 0

--- a/plugins/session/hooks/handlers/save-commit-gate.sh
+++ b/plugins/session/hooks/handlers/save-commit-gate.sh
@@ -51,12 +51,15 @@ CMD_HEAD="${CMD%%commit*}"
 # 9c golden corpus pins it). Used for the no-workspace path AND for the child
 # plane under a workspace.
 gate_check_plane() {
-    local dir="$1"
+    local dir="$1" forced="${2:-0}"
     # Does this commit touch Memory/? Two signals, either suffices:
     #   (a) the command head references Memory/
     #   (b) the staged set already contains Memory/ paths
-    local touches=0
-    printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && touches=1
+    # A caller that ALREADY established candidacy (workspace branch: dirty
+    # state + -a/pathspec) passes forced=1 — re-deriving from staged-only
+    # here would re-open the commit -a / pathspec bypass (pass-2).
+    local touches="$forced"
+    [[ $touches -eq 0 ]] && printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && touches=1
     if [[ $touches -eq 0 ]]; then
         if git -C "$dir" diff --cached --name-only 2>/dev/null | grep -q '^Memory/'; then
             touches=1
@@ -140,45 +143,150 @@ MEM_ROOT="$(printf '%s' "$MAPPING" | jq -r '.memory_root // empty' 2>/dev/null |
 CHILD_TOP="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
 HEAD_REF=0
 printf '%s' "$CMD_HEAD" | grep -q 'Memory/' && HEAD_REF=1
+WS_GUESS="${WS_MANIFEST%/.asha/workspace.json}"
+
+# _mem_hit REPO REL MODE — does the repo have Memory-plane paths in the given
+# git listing? Literal prefix comparison, never regex (a REL with metachars
+# must not false-match). Empty REL means the whole repo IS the plane.
+_mem_hit() {
+    local repo="$1" rel="$2" mode="$3" p
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        if [[ -z "$rel" || "$p" == "$rel"/* ]]; then return 0; fi
+    done < <(
+        if [[ "$mode" == staged ]]; then
+            git -C "$repo" diff --cached --name-only 2>/dev/null
+        else
+            # tracked modifications only (-uno): commit -a commits these
+            git -C "$repo" status --porcelain -uno 2>/dev/null | cut -c4-
+        fi
+    )
+    return 1
+}
+# any Memory state at all (staged, dirty-tracked, or untracked) — used for
+# the compound rule's cleanliness requirement, where an about-to-be-added
+# NEW file matters too.
+_mem_any() {
+    local repo="$1" rel="$2" p
+    _mem_hit "$repo" "$rel" staged && return 0
+    while IFS= read -r p; do
+        [[ -z "$p" ]] && continue
+        if [[ -z "$rel" || "$p" == "$rel"/* ]]; then return 0; fi
+    done < <(git -C "$repo" status --porcelain 2>/dev/null | cut -c4-)
+    return 1
+}
 
 if [[ -z "$PLANE_BASE" || -z "$COMMIT_REPO" || -z "$MEM_ROOT" ]]; then
     # Manifest present but not validatable (invalid manifest, or
     # python3/save_scope missing). Fail closed for anything with a visible
-    # Memory signal; a commit with no Memory signal anywhere stays allowed.
-    STAGED_ANY=0
-    [[ -n "$CHILD_TOP" ]] \
-        && git -C "$CHILD_TOP" diff --cached --name-only 2>/dev/null | grep -q '^Memory/' \
-        && STAGED_ANY=1
-    if [[ $HEAD_REF -eq 1 || $STAGED_ANY -eq 1 ]]; then
+    # Memory signal IN EITHER PLANE — the workspace root is known from the
+    # walk even when the resolver is not (pass-2: checking only the child
+    # left workspace-staged Memory ungated exactly when the gate was blind).
+    SIGNAL=0
+    [[ $HEAD_REF -eq 1 ]] && SIGNAL=1
+    [[ -n "$CHILD_TOP" ]] && _mem_hit "$CHILD_TOP" "Memory" staged && SIGNAL=1
+    [[ -n "$CHILD_TOP" ]] && _mem_hit "$CHILD_TOP" "Memory" dirty && SIGNAL=1
+    _mem_hit "$WS_GUESS" "Memory" staged && SIGNAL=1
+    _mem_hit "$WS_GUESS" "Memory" dirty && SIGNAL=1
+    if [[ $SIGNAL -eq 1 ]]; then
         pretooluse_policy_deny "save-commit-gate" \
-            "Memory/ commit refused: a workspace manifest exists at ${WS_MANIFEST%/.asha/workspace.json} but cannot be validated (invalid manifest, or python3/save_scope.py unavailable) — failing closed. Check: asha workspace status" \
+            "Memory/ commit refused: a workspace manifest exists at $WS_GUESS but cannot be validated (invalid manifest, or python3/save_scope.py unavailable) — failing closed. Check: asha workspace status" \
             " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
         exit $?
     fi
     exit 0
 fi
 
-REL_MEM="${MEM_ROOT#"$COMMIT_REPO"/}"
-STAGED_WS=0
-git -C "$COMMIT_REPO" diff --cached --name-only 2>/dev/null | grep -q "^$REL_MEM/" && STAGED_WS=1
-STAGED_CHILD=0
-if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]]; then
-    git -C "$CHILD_TOP" diff --cached --name-only 2>/dev/null | grep -q '^Memory/' && STAGED_CHILD=1
-fi
+REL_MEM="$(printf '%s' "$MAPPING" | jq -r '.memory_rel // "Memory"' 2>/dev/null || echo Memory)"
 
-# A bare Memory/ reference in the command head attributes to the payload-cwd
-# repo (the default git target). A compound that -C's into ANOTHER repo is
-# deliberately not parsed; if its plane lacks staged state now, its own
-# commit-stage state check or proof requirement catches it — conservative,
-# never permissive.
-CAND_CHILD=$STAGED_CHILD
-CAND_WS=$STAGED_WS
-if [[ $HEAD_REF -eq 1 ]]; then
-    if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]]; then
-        CAND_CHILD=1
-    else
-        CAND_WS=1
+# Commit-tail flags, with quoted spans stripped so a commit MESSAGE that
+# mentions Memory/ or -a never counts (same principle as CMD_HEAD).
+COMMIT_TAIL="${CMD#*commit}"
+TAIL_STRIPPED="$(printf '%s' "$COMMIT_TAIL" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null || true)"
+HAS_ALL=0
+printf '%s' "$TAIL_STRIPPED" | grep -Eq -- '(^|[[:space:]])--all([[:space:]]|$)|(^|[[:space:]])-[a-z]*a[a-z]*([[:space:]]|$)' && HAS_ALL=1
+PATHSPEC_MEM=0
+printf '%s' "$TAIL_STRIPPED" | grep -q 'Memory/' && PATHSPEC_MEM=1
+
+# Candidate planes by STATE: staged always counts; dirty-tracked counts when
+# the commit form can pick it up directly (-a/--all, or an unquoted Memory
+# pathspec after the commit token — pass-2: staged-only let `commit -a` and
+# `git commit Memory/x` bypass the gate entirely).
+CAND_CHILD=0
+CAND_WS=0
+if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]]; then
+    _mem_hit "$CHILD_TOP" "Memory" staged && CAND_CHILD=1
+    [[ $HAS_ALL -eq 1 || $PATHSPEC_MEM -eq 1 ]] \
+        && _mem_hit "$CHILD_TOP" "Memory" dirty && CAND_CHILD=1
+fi
+_mem_hit "$COMMIT_REPO" "$REL_MEM" staged && CAND_WS=1
+[[ $HAS_ALL -eq 1 || $PATHSPEC_MEM -eq 1 ]] \
+    && _mem_hit "$COMMIT_REPO" "$REL_MEM" dirty && CAND_WS=1
+
+ws_plane_check() {   # verify + CONSUME the workspace proof
+    if [[ -f "$PLANE_BASE/Work/markers/silence" ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Workspace Memory commit refused: the workspace's Work/markers/silence is active." \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        return $?
     fi
+    [[ -f "$MEM_ROOT/activeContext.md" ]] || return 0   # first-init
+    local reason ok=0
+    reason="$(python3 "$SS_TOOL" verify --scope workspace --start "$PROJECT_DIR" 2>/dev/null)" || ok=$?
+    if [[ $ok -ne 0 ]]; then
+        pretooluse_policy_deny "save-commit-gate" \
+            "Workspace Memory commit refused: ${reason:-no valid workspace save proof}. Run /session:save --scope workspace (it writes the proof via save_scope.py before committing)." \
+            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+        return $?
+    fi
+    # Consume-on-use: a proof authorizes exactly one commit (pass-2: an
+    # unconsumed proof replayed indefinitely while activeContext was
+    # unchanged). If the commit itself then fails, /save re-proves.
+    rm -f "$PLANE_BASE/Work/markers/save-gates-ok" 2>/dev/null || true
+    return 0
+}
+
+# _legacy_marker_valid DIR — silent validity probe of the single-plane
+# marker (used by the compound rule; gate_check_plane does the deny texts).
+_legacy_marker_valid() {
+    local dir="$1" m="$1/Work/markers/save-gates-ok" ms ds
+    [[ -f "$m" ]] || return 1
+    ms="$(jq -r '.ac_sha256 // empty' "$m" 2>/dev/null || true)"
+    ds="$(sha256sum "$dir/Memory/activeContext.md" 2>/dev/null | cut -d' ' -f1 || true)"
+    [[ -n "$ms" && -n "$ds" && "$ms" == "$ds" ]]
+}
+
+# Compound add-of-Memory-then-commit: PreToolUse runs BEFORE the add, so
+# staged state cannot attribute the plane, and pass-2 proved cwd attribution
+# is launderable via -C. Rule: allow only when EXACTLY ONE plane holds a
+# valid proof AND the other plane has no Memory state at all (including
+# untracked — the add would stage it); anything else denies.
+if printf '%s' "$CMD_HEAD" | grep -Eq 'add[^|;&]*Memory/'; then
+    CHILD_READY=0
+    WS_READY=0
+    if [[ -n "$CHILD_TOP" && "$CHILD_TOP" != "$COMMIT_REPO" ]] \
+        && _legacy_marker_valid "$CHILD_TOP" \
+        && ! _mem_any "$COMMIT_REPO" "$REL_MEM"; then
+        CHILD_READY=1
+    fi
+    if python3 "$SS_TOOL" verify --scope workspace --start "$PROJECT_DIR" >/dev/null 2>&1; then
+        if [[ -z "$CHILD_TOP" || "$CHILD_TOP" == "$COMMIT_REPO" ]] \
+            || ! _mem_any "$CHILD_TOP" "Memory"; then
+            WS_READY=1
+        fi
+    fi
+    if [[ $CHILD_READY -eq 1 && $WS_READY -eq 0 ]]; then
+        gate_check_plane "$CHILD_TOP"
+        exit $?
+    fi
+    if [[ $WS_READY -eq 1 && $CHILD_READY -eq 0 ]]; then
+        ws_plane_check
+        exit $?
+    fi
+    pretooluse_policy_deny "save-commit-gate" \
+        "Memory/ commit refused: a compound add-and-commit under a workspace cannot be attributed to one plane (proofs: child=$CHILD_READY workspace=$WS_READY). Stage first and commit separately, or use /session:save (child) / /session:save --scope workspace." \
+        " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
+    exit $?
 fi
 
 if [[ $CAND_CHILD -eq 1 && $CAND_WS -eq 1 ]]; then
@@ -189,27 +297,13 @@ if [[ $CAND_CHILD -eq 1 && $CAND_WS -eq 1 ]]; then
 fi
 
 if [[ $CAND_CHILD -eq 1 ]]; then
-    gate_check_plane "$CHILD_TOP"
+    gate_check_plane "$CHILD_TOP" 1
     exit $?
 fi
 
 if [[ $CAND_WS -eq 1 ]]; then
-    if [[ -f "$PLANE_BASE/Work/markers/silence" ]]; then
-        pretooluse_policy_deny "save-commit-gate" \
-            "Workspace Memory commit refused: the workspace's Work/markers/silence is active." \
-            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
-        exit $?
-    fi
-    # First-init exception, same as the single-plane gate.
-    [[ -f "$MEM_ROOT/activeContext.md" ]] || exit 0
-    WS_REASON="$(python3 "$SS_TOOL" verify --scope workspace --start "$PROJECT_DIR" 2>/dev/null)" && WS_OK=0 || WS_OK=$?
-    if [[ $WS_OK -ne 0 ]]; then
-        pretooluse_policy_deny "save-commit-gate" \
-            "Workspace Memory commit refused: ${WS_REASON:-no valid workspace save proof}. Run /session:save --scope workspace (it writes the proof via save_scope.py before committing)." \
-            " (override: ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)"
-        exit $?
-    fi
-    exit 0
+    ws_plane_check
+    exit $?
 fi
 
 exit 0

--- a/plugins/session/hooks/handlers/save-preflight-stop.sh
+++ b/plugins/session/hooks/handlers/save-preflight-stop.sh
@@ -27,20 +27,42 @@ TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || tr
 SID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 ATTEMPTS=$(jq -r '.attempts // 0' "$MARKER" 2>/dev/null || echo 0)
 [[ "$ATTEMPTS" =~ ^[0-9]+$ ]] || ATTEMPTS=0
+# Workspace v1 (issue #36): a v2 locator carries the plane it belongs to.
+# Legacy markers have no scope field and take the original path untouched.
+MARKER_SCOPE=$(jq -r '.scope // empty' "$MARKER" 2>/dev/null || true)
+MARKER_PLANE=$(jq -r '.plane_base // empty' "$MARKER" 2>/dev/null || true)
 
-ENGINE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../tools" && pwd)/save_preflight.py"
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../tools" && pwd)"
+ENGINE="$TOOLS_DIR/save_preflight.py"
 HOOK_LOG="$PROJECT_DIR/Memory/events/save-preflight-hook.log"
 mkdir -p "$(dirname "$HOOK_LOG")" 2>/dev/null || true
 
-RESULT=$(ASHA_TRANSCRIPT_PATH="$TRANSCRIPT" ASHA_SESSION_ID="$SID" CLAUDE_CODE_SESSION_ID="$SID" \
-    python3 "$ENGINE" --mode enforce \
-        --project-dir "$PROJECT_DIR" \
-        --transcript "$TRANSCRIPT" \
-        --session-id "$SID" \
-        2>>"$HOOK_LOG" || echo '{"hard_fail":false}')
+if [[ "$MARKER_SCOPE" == "workspace" && -n "$MARKER_PLANE" ]]; then
+    # Workspace plane: the session-transcript gates are project-scoped by
+    # design (the workspace plane has no transcript of its own in v1), so
+    # enforcement here is the structural proof: mapping + activeContext sha
+    # via save_scope.py, logged under the PLANE's own tree.
+    HOOK_LOG="$MARKER_PLANE/Memory/events/save-preflight-hook.log"
+    mkdir -p "$(dirname "$HOOK_LOG")" 2>/dev/null || true
+    if WS_REASON=$(python3 "$TOOLS_DIR/save_scope.py" verify \
+            --scope workspace --start "$PROJECT_DIR" 2>>"$HOOK_LOG"); then
+        HARD_FAIL=false
+        REASON="ok"
+    else
+        HARD_FAIL=true
+        REASON="workspace save proof failed: ${WS_REASON:-unverifiable}"
+    fi
+else
+    RESULT=$(ASHA_TRANSCRIPT_PATH="$TRANSCRIPT" ASHA_SESSION_ID="$SID" CLAUDE_CODE_SESSION_ID="$SID" \
+        python3 "$ENGINE" --mode enforce \
+            --project-dir "$PROJECT_DIR" \
+            --transcript "$TRANSCRIPT" \
+            --session-id "$SID" \
+            2>>"$HOOK_LOG" || echo '{"hard_fail":false}')
 
-HARD_FAIL=$(echo "$RESULT" | jq -r '.hard_fail // false' 2>/dev/null || echo false)
-REASON=$(echo "$RESULT" | jq -r '.reason // "save pre-flight gate failed"' 2>/dev/null || echo "save pre-flight gate failed")
+    HARD_FAIL=$(echo "$RESULT" | jq -r '.hard_fail // false' 2>/dev/null || echo false)
+    REASON=$(echo "$RESULT" | jq -r '.reason // "save pre-flight gate failed"' 2>/dev/null || echo "save pre-flight gate failed")
+fi
 
 # All gates pass -> clear marker, allow stop (save completes clean).
 if [[ "$HARD_FAIL" != "true" ]]; then
@@ -57,9 +79,17 @@ if [[ "$ATTEMPTS" -ge 3 || "$STOP_ACTIVE" == "true" ]]; then
     exit 0
 fi
 
-# Block and force remediation; record the attempt.
+# Block and force remediation; record the attempt. A v2 locator's routing
+# fields MUST survive the rewrite or attempt 2 would fall back to the wrong
+# (session-preflight) verifier for a workspace save.
 NEW=$((ATTEMPTS + 1))
-printf '{"created":"%s","attempts":%d}\n' "$(date -u +%FT%TZ)" "$NEW" > "$MARKER"
+if [[ "$MARKER_SCOPE" == "workspace" && -n "$MARKER_PLANE" ]]; then
+    jq -n --arg c "$(date -u +%FT%TZ)" --argjson n "$NEW" \
+        --arg s "$MARKER_SCOPE" --arg p "$MARKER_PLANE" \
+        '{created:$c, attempts:$n, scope:$s, plane_base:$p}' > "$MARKER"
+else
+    printf '{"created":"%s","attempts":%d}\n' "$(date -u +%FT%TZ)" "$NEW" > "$MARKER"
+fi
 echo "[$(date -u +%FT%TZ)] BLOCK attempt ${NEW}/3: ${REASON}" >>"$HOOK_LOG"
 jq -n --arg r "$REASON" --arg n "$NEW" \
     '{decision:"block", reason:("Session-save pre-flight gate failed (attempt " + $n + "/3). " + $r)}'

--- a/plugins/session/hooks/handlers/save-preflight-stop.sh
+++ b/plugins/session/hooks/handlers/save-preflight-stop.sh
@@ -41,9 +41,10 @@ if [[ "$MARKER_SCOPE" == "workspace" && -n "$MARKER_PLANE" ]]; then
     # Workspace plane: the session-transcript gates are project-scoped by
     # design (the workspace plane has no transcript of its own in v1), so
     # enforcement here is the structural proof: mapping + activeContext sha
-    # via save_scope.py, logged under the PLANE's own tree.
-    HOOK_LOG="$MARKER_PLANE/Memory/events/save-preflight-hook.log"
-    mkdir -p "$(dirname "$HOOK_LOG")" 2>/dev/null || true
+    # via save_scope.py. Logs stay under PROJECT_DIR — a marker-supplied
+    # plane_base must never choose a write location (pass-2: crafted marker
+    # = arbitrary-directory log creation). plane_base is used only for the
+    # attempt-rewrite fields below, where it is inert routing data.
     if WS_REASON=$(python3 "$TOOLS_DIR/save_scope.py" verify \
             --scope workspace --start "$PROJECT_DIR" 2>>"$HOOK_LOG"); then
         HARD_FAIL=false

--- a/plugins/session/tools/project-root.sh
+++ b/plugins/session/tools/project-root.sh
@@ -67,3 +67,30 @@ asha_detect_project_root() {
     echo "$dir"
     return 0
 }
+
+# asha_find_workspace_manifest [START]
+#   Pure-bash EXISTENCE walk for .asha/workspace.json — the cheap half of
+#   workspace detection, for hot paths (PreToolUse gates) that must not pay
+#   a python start when no workspace exists. Mirrors project_root.py
+#   detect_workspace bounds exactly: $HOME and / are both EXCLUSIVE, with
+#   canonical comparison. VALIDATION stays in python — a caller that finds a
+#   manifest here must hand off to project_root.py / save_scope.py and fail
+#   closed if that handoff is unavailable. Prints the manifest path, or
+#   nothing; rc 0 always.
+asha_find_workspace_manifest() {
+    local search home_canon
+    search="$(cd -P "${1:-$PWD}" 2>/dev/null && pwd)" || { echo ""; return 0; }
+    home_canon="$(cd -P "$HOME" 2>/dev/null && pwd)" || home_canon=""
+    while [[ -n "$search" && "$search" != "/" ]]; do
+        if [[ -n "$home_canon" && "$search" == "$home_canon" ]]; then
+            break
+        fi
+        if [[ -f "$search/.asha/workspace.json" ]]; then
+            echo "$search/.asha/workspace.json"
+            return 0
+        fi
+        search="$(dirname "$search")"
+    done
+    echo ""
+    return 0
+}

--- a/plugins/session/tools/project-root.sh
+++ b/plugins/session/tools/project-root.sh
@@ -80,12 +80,17 @@ asha_detect_project_root() {
 asha_find_workspace_manifest() {
     local search home_canon
     search="$(cd -P "${1:-$PWD}" 2>/dev/null && pwd)" || { echo ""; return 0; }
-    home_canon="$(cd -P "$HOME" 2>/dev/null && pwd)" || home_canon=""
+    # ${HOME:-}: unset HOME must not print an unbound-variable diagnostic
+    # under a caller's set -u (pass-2: golden byte-equivalence).
+    home_canon="$(cd -P "${HOME:-}" 2>/dev/null && pwd)" || home_canon=""
     while [[ -n "$search" && "$search" != "/" ]]; do
         if [[ -n "$home_canon" && "$search" == "$home_canon" ]]; then
             break
         fi
-        if [[ -f "$search/.asha/workspace.json" ]]; then
+        # -e OR -L, not -f: a directory, socket, or broken symlink at the
+        # manifest path must route to the (fail-closed) validation branch,
+        # not silently read as "no manifest" (pass-2).
+        if [[ -e "$search/.asha/workspace.json" || -L "$search/.asha/workspace.json" ]]; then
             echo "$search/.asha/workspace.json"
             return 0
         fi

--- a/plugins/session/tools/save_scope.py
+++ b/plugins/session/tools/save_scope.py
@@ -94,13 +94,31 @@ def resolve_plane(scope: str, start: Optional[Path] = None
                 f"shared_git_root ({sgr}) is not the root of a git worktree "
                 f"— workspace memory commits are impossible; failing closed",
             )]
+        # Canonical runtime containment (defense-in-depth over the lexical
+        # validator): memory_root must land inside commit_repo AFTER symlink
+        # resolution, and memory_rel is computed here so consumers never
+        # re-derive it with string stripping (pass-2: an absolute REL from a
+        # failed strip silently never matched staged paths).
+        try:
+            mem_root = (ws_root / mem.get("operational_root",
+                                          "Memory")).resolve()
+            sgr_resolved = sgr.resolve()
+            memory_rel = str(mem_root.relative_to(sgr_resolved))
+        except (ValueError, OSError, RuntimeError) as exc:
+            return None, [_err(
+                "containment_violation",
+                f"operational_root does not resolve inside shared_git_root "
+                f"({exc}) — failing closed",
+            )]
+        if memory_rel == ".":
+            memory_rel = ""
         return {
             "version": PROOF_VERSION,
             "scope": "workspace",
             "plane_base": str(ws_root),
-            "memory_root": str(ws_root / mem.get("operational_root",
-                                                 "Memory")),
-            "commit_repo": str(sgr),
+            "memory_root": str(mem_root),
+            "memory_rel": memory_rel,
+            "commit_repo": str(sgr_resolved),
         }, []
 
     # scope == "repo": the active child project. Outside a workspace this is
@@ -157,6 +175,7 @@ def resolve_plane(scope: str, start: Optional[Path] = None
         "scope": "repo",
         "plane_base": str(base),
         "memory_root": str(base / "Memory"),
+        "memory_rel": "Memory",
         "commit_repo": str(base),
     }, []
 
@@ -174,7 +193,12 @@ def _marker_path(mapping: dict) -> Path:
 
 
 def write_proof(mapping: dict) -> str:
-    """Write the versioned proof at the plane base. Returns the path."""
+    """Write the versioned proof at the plane base. Returns the path.
+
+    Raises nothing: filesystem failures surface as a typed exception-free
+    empty return via the CLI wrapper; library callers get ValueError with a
+    typed message (kept simple — the CLI is the shipped surface).
+    """
     sha = _ac_sha(mapping)
     record = {
         "version": PROOF_VERSION,
@@ -255,12 +279,19 @@ def main(argv: List[str]) -> int:
     if verb == "resolve":
         print(json.dumps(mapping, indent=2, sort_keys=True))
         return 0
-    if verb == "write-proof":
-        print(write_proof(mapping))
-        return 0
-    ok, reason = verify_proof(mapping)
-    print(reason)
-    return 0 if ok else 1
+    # Totality at the CLI boundary (pass-2): filesystem failures and
+    # malformed mappings are typed verdicts, never tracebacks.
+    try:
+        if verb == "write-proof":
+            print(write_proof(mapping))
+            return 0
+        ok, reason = verify_proof(mapping)
+        print(reason)
+        return 0 if ok else 1
+    except (OSError, KeyError, ValueError) as exc:
+        print(json.dumps({"errors": [
+            _err("proof_io_failed", f"{type(exc).__name__}: {exc}")]}))
+        return 1
 
 
 if __name__ == "__main__":

--- a/plugins/session/tools/save_scope.py
+++ b/plugins/session/tools/save_scope.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+save_scope.py — scope resolution + versioned save proof (v1, issue #36).
+
+The writer-side enforcement seam from the ratified design memo: the entity
+that COMMITS memory knows its full plane mapping and must carry the proof —
+the PreToolUse gate is defense-in-depth for ad-hoc shell git, not the
+primary mechanism.
+
+A plane mapping keeps THREE distinct values (conflating them is how the
+cross-plane bypass happens):
+  plane_base   — where markers, logs, and this plane's Memory/ live
+  memory_root  — the ONLY pathspec a save for this scope may stage
+  commit_repo  — the git worktree the commit lands in
+
+Scopes (per the ratified proposal):
+  repo       — the active child project (or the sole project outside any
+               workspace): plane_base = commit_repo = the project root.
+               From the workspace root itself this FAILS with guidance.
+  workspace  — plane_base = workspace root, commit_repo = shared_git_root,
+               memory_root = the workspace operational plane. Requires a
+               valid manifest and a real git worktree at shared_git_root —
+               fail closed otherwise.
+
+Proof: Work/markers/save-gates-ok at plane_base, version 2 — a JSON record
+binding the mapping AND the sha256 of the plane's Memory/activeContext.md.
+Any post-proof mutation, or any attempt to satisfy one plane's commit with
+another plane's proof, fails verification. (Version 1 is the legacy marker
+written by save-preflight-env.sh for the no-workspace path; the commit gate
+accepts both, each only for its own plane.)
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import project_root  # noqa: E402
+
+PROOF_VERSION = 2
+_MARKER_REL = Path("Work") / "markers" / "save-gates-ok"
+
+
+def _err(code: str, message: str) -> dict:
+    return {"code": code, "field": "", "message": message}
+
+
+def _is_repo_root(path: Path) -> bool:
+    try:
+        res = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if res.returncode != 0:
+        return False
+    try:
+        return Path(res.stdout.strip()).resolve() == path.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def resolve_plane(scope: str, start: Optional[Path] = None
+                  ) -> Tuple[Optional[dict], List[dict]]:
+    """Resolve a scope into its plane mapping. Fail closed, typed errors."""
+    if scope not in ("repo", "workspace"):
+        return None, [_err("invalid_scope",
+                           f"scope must be repo|workspace, got {scope!r}")]
+    start_path = Path(start if start is not None else Path.cwd())
+    det = project_root.detect_workspace(start=start_path)
+    if det.errors:
+        return None, [e._asdict() for e in det.errors]
+
+    if scope == "workspace":
+        if det.root is None:
+            return None, [_err("no_workspace",
+                               "no .asha/workspace.json in any ancestor — "
+                               "--scope workspace requires a workspace")]
+        manifest = det.manifest
+        assert manifest is not None  # det.errors empty + root set => valid
+        ws_root = det.root
+        mem = manifest.get("memory", {})
+        sgr_rel = mem.get("shared_git_root", ".")
+        sgr = ws_root if sgr_rel == "." else (ws_root / sgr_rel).resolve()
+        if not _is_repo_root(sgr):
+            return None, [_err(
+                "shared_git_root_not_git",
+                f"shared_git_root ({sgr}) is not the root of a git worktree "
+                f"— workspace memory commits are impossible; failing closed",
+            )]
+        return {
+            "version": PROOF_VERSION,
+            "scope": "workspace",
+            "plane_base": str(ws_root),
+            "memory_root": str(ws_root / mem.get("operational_root",
+                                                 "Memory")),
+            "commit_repo": str(sgr),
+        }, []
+
+    # scope == "repo": the active child project. Outside a workspace this is
+    # simply the surrounding project; inside one, cwd must be in a child.
+    if det.root is not None:
+        manifest = det.manifest
+        assert manifest is not None
+        active = None
+        try:
+            resolved = start_path.resolve()
+        except (OSError, RuntimeError, ValueError):
+            resolved = None
+        if resolved is not None:
+            best_depth = -1
+            for entry in manifest.get("repositories", []):
+                rel = entry.get("path")
+                if not isinstance(rel, str):
+                    continue
+                try:
+                    cand = (det.root / rel).resolve()
+                except (OSError, RuntimeError, ValueError):
+                    continue
+                if cand == resolved or cand in resolved.parents:
+                    if len(cand.parts) > best_depth:
+                        active, best_depth = cand, len(cand.parts)
+        if active is None:
+            return None, [_err(
+                "no_active_repo",
+                "--scope repo needs the current directory inside a declared "
+                "child repository; from the workspace root use "
+                "--scope workspace, or cd into a child",
+            )]
+        base = active
+    else:
+        top = None
+        try:
+            res = subprocess.run(
+                ["git", "-C", str(start_path), "rev-parse",
+                 "--show-toplevel"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if res.returncode == 0:
+                top = Path(res.stdout.strip())
+        except (OSError, subprocess.SubprocessError):
+            pass
+        if top is None:
+            return None, [_err("no_repo",
+                               "not inside a git repository and no "
+                               "workspace manifest found")]
+        base = top
+
+    return {
+        "version": PROOF_VERSION,
+        "scope": "repo",
+        "plane_base": str(base),
+        "memory_root": str(base / "Memory"),
+        "commit_repo": str(base),
+    }, []
+
+
+def _ac_sha(mapping: dict) -> Optional[str]:
+    ac = Path(mapping["memory_root"]) / "activeContext.md"
+    try:
+        return hashlib.sha256(ac.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _marker_path(mapping: dict) -> Path:
+    return Path(mapping["plane_base"]) / _MARKER_REL
+
+
+def write_proof(mapping: dict) -> str:
+    """Write the versioned proof at the plane base. Returns the path."""
+    sha = _ac_sha(mapping)
+    record = {
+        "version": PROOF_VERSION,
+        "scope": mapping["scope"],
+        "plane_base": mapping["plane_base"],
+        "memory_root": mapping["memory_root"],
+        "commit_repo": mapping["commit_repo"],
+        "ac_sha256": sha or "",
+    }
+    marker = _marker_path(mapping)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps(record, indent=2, sort_keys=True),
+                      encoding="utf-8")
+    return str(marker)
+
+
+def verify_proof(mapping: dict) -> Tuple[bool, str]:
+    """Verify the plane's proof against the mapping and disk state."""
+    marker = _marker_path(mapping)
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False, f"no proof (or unreadable) at {marker}"
+    if data.get("version") != PROOF_VERSION:
+        return False, f"proof version {data.get('version')!r} != {PROOF_VERSION}"
+    for key in ("scope", "plane_base", "memory_root", "commit_repo"):
+        if data.get(key) != mapping.get(key):
+            return False, (f"proof {key} mismatch: proof has "
+                           f"{data.get(key)!r}, mapping requires "
+                           f"{mapping.get(key)!r} — a proof satisfies only "
+                           f"its own plane")
+    disk = _ac_sha(mapping)
+    if not data.get("ac_sha256") or disk is None \
+            or data["ac_sha256"] != disk:
+        return False, ("activeContext.md changed after the proof was "
+                       "written (or is unreadable) — the proof is stale")
+    return True, "ok"
+
+
+def _resolve_from_args(scope: str, start: Optional[str]
+                       ) -> Tuple[Optional[dict], List[dict]]:
+    return resolve_plane(scope, Path(start) if start else None)
+
+
+def main(argv: List[str]) -> int:
+    """CLI: resolve | write-proof | verify, each --scope S [--start D].
+
+    resolve prints the mapping JSON (rc 0) or {errors} (rc 1).
+    write-proof resolves then writes the proof (prints marker path).
+    verify resolves then verifies (rc 0 ok / 1 fail, reason on stdout).
+    """
+    args = argv[1:]
+    if not args or args[0] not in ("resolve", "write-proof", "verify"):
+        print("usage: save_scope.py resolve|write-proof|verify "
+              "--scope repo|workspace [--start DIR]", file=sys.stderr)
+        return 2
+    verb, rest = args[0], args[1:]
+    scope, start = None, None
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--scope" and i + 1 < len(rest):
+            scope = rest[i + 1]; i += 1
+        elif rest[i] == "--start" and i + 1 < len(rest):
+            start = rest[i + 1]; i += 1
+        else:
+            print("usage: save_scope.py resolve|write-proof|verify "
+                  "--scope repo|workspace [--start DIR]", file=sys.stderr)
+            return 2
+        i += 1
+    if not scope:
+        print("usage: --scope is required", file=sys.stderr)
+        return 2
+
+    mapping, errors = _resolve_from_args(scope, start)
+    if mapping is None:
+        print(json.dumps({"errors": errors}, indent=2))
+        return 1
+    if verb == "resolve":
+        print(json.dumps(mapping, indent=2, sort_keys=True))
+        return 0
+    if verb == "write-proof":
+        print(write_proof(mapping))
+        return 0
+    ok, reason = verify_proof(mapping)
+    print(reason)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/python/test_save_scope.py
+++ b/tests/python/test_save_scope.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Tests for save_scope (workspace v1, delivery issue 4 — issue #36).
+
+The writer-side enforcement seam from the ratified design memo: resolve a
+save scope into its plane mapping — plane_base (markers/logs), memory_root
+(staged pathspec), commit_repo (git target) as THREE distinct values —
+write a versioned structured proof at the plane base, and verify it
+immediately before any commit. The PreToolUse gate is defense-in-depth;
+THIS is the primary contract.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "plugins" / "session" / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+import save_scope as ss  # type: ignore[reportMissingImports]  # noqa: E402
+
+
+def _git(*args, cwd=None):
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=master", *args], cwd=cwd,
+        check=True, capture_output=True, text=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+
+class ScopeFixture(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="asha_scope_")).resolve()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.tmp, True))
+        self._home = os.environ.get("HOME")
+        home = self.tmp / "home"
+        home.mkdir()
+        os.environ["HOME"] = str(home)
+        self.addCleanup(self._restore_home)
+        # Workspace: sgr = ws root, one child repo, workspace Memory plane.
+        self.ws = home / "Code" / "thallus"
+        (self.ws / ".asha").mkdir(parents=True)
+        (self.ws / ".asha" / "workspace.json").write_text(json.dumps({
+            "version": 1, "workspace_name": "thallus",
+            "repositories": [{"path": "egregore"}],
+        }), encoding="utf-8")
+        (self.ws / "Memory").mkdir()
+        (self.ws / "Memory" / "activeContext.md").write_text(
+            "# ws context\n", encoding="utf-8")
+        _git("init", "-q", str(self.ws))
+        self.child = self.ws / "egregore"
+        (self.child / "Memory").mkdir(parents=True)
+        (self.child / "Memory" / "activeContext.md").write_text(
+            "# child context\n", encoding="utf-8")
+        _git("init", "-q", str(self.child))
+
+    def _restore_home(self):
+        if self._home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._home
+
+
+class ResolveCases(ScopeFixture):
+    def test_workspace_scope_mapping(self):
+        mapping, errors = ss.resolve_plane("workspace", start=self.child)
+        self.assertEqual(errors, [])
+        self.assertEqual(mapping["plane_base"], str(self.ws))
+        self.assertEqual(mapping["commit_repo"], str(self.ws))
+        self.assertEqual(mapping["memory_root"], str(self.ws / "Memory"))
+        self.assertEqual(mapping["scope"], "workspace")
+
+    def test_repo_scope_maps_to_child(self):
+        mapping, errors = ss.resolve_plane("repo", start=self.child)
+        self.assertEqual(errors, [])
+        self.assertEqual(mapping["plane_base"], str(self.child))
+        self.assertEqual(mapping["commit_repo"], str(self.child))
+        self.assertEqual(mapping["memory_root"], str(self.child / "Memory"))
+
+    def test_workspace_scope_without_manifest_is_typed_error(self):
+        lone = self.tmp / "home" / "solo"
+        lone.mkdir(parents=True)
+        mapping, errors = ss.resolve_plane("workspace", start=lone)
+        self.assertIsNone(mapping)
+        self.assertEqual({e["code"] for e in errors}, {"no_workspace"})
+
+    def test_workspace_scope_invalid_manifest_fails_closed(self):
+        (self.ws / ".asha" / "workspace.json").write_text(
+            '{"version": 9}', encoding="utf-8")
+        mapping, errors = ss.resolve_plane("workspace", start=self.child)
+        self.assertIsNone(mapping)
+        self.assertTrue(errors)
+
+    def test_workspace_scope_requires_sgr_worktree(self):
+        # Same layout but the workspace root is not a git repo: commits are
+        # impossible; resolution must fail closed, not stage into nothing.
+        import shutil
+        shutil.rmtree(self.ws / ".git")
+        mapping, errors = ss.resolve_plane("workspace", start=self.child)
+        self.assertIsNone(mapping)
+        self.assertEqual({e["code"] for e in errors},
+                         {"shared_git_root_not_git"})
+
+    def test_repo_scope_at_workspace_root_is_error(self):
+        # Pinned in the proposal: --scope repo from the workspace root fails
+        # with guidance rather than guessing a child.
+        mapping, errors = ss.resolve_plane("repo", start=self.ws)
+        self.assertIsNone(mapping)
+        self.assertEqual({e["code"] for e in errors}, {"no_active_repo"})
+
+
+class ProofCases(ScopeFixture):
+    def test_proof_roundtrip(self):
+        mapping, _ = ss.resolve_plane("workspace", start=self.child)
+        path = ss.write_proof(mapping)
+        self.assertTrue(Path(path).is_file())
+        ok, reason = ss.verify_proof(mapping)
+        self.assertTrue(ok, reason)
+
+    def test_proof_is_versioned_structured(self):
+        mapping, _ = ss.resolve_plane("workspace", start=self.child)
+        path = ss.write_proof(mapping)
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        self.assertEqual(data["version"], 2)
+        self.assertEqual(data["scope"], "workspace")
+        self.assertEqual(data["plane_base"], str(self.ws))
+        self.assertEqual(data["commit_repo"], str(self.ws))
+        self.assertTrue(data["ac_sha256"])
+
+    def test_stale_activecontext_fails_verification(self):
+        mapping, _ = ss.resolve_plane("workspace", start=self.child)
+        ss.write_proof(mapping)
+        (self.ws / "Memory" / "activeContext.md").write_text(
+            "# mutated after proof\n", encoding="utf-8")
+        ok, reason = ss.verify_proof(mapping)
+        self.assertFalse(ok)
+        self.assertIn("activeContext", reason)
+
+    def test_wrong_plane_proof_rejected(self):
+        # A proof written for the CHILD plane must not satisfy the
+        # workspace plane (cross-plane laundering, memo failure table).
+        child_map, _ = ss.resolve_plane("repo", start=self.child)
+        ws_map, _ = ss.resolve_plane("workspace", start=self.child)
+        ss.write_proof(child_map)
+        ok, _ = ss.verify_proof(ws_map)
+        self.assertFalse(ok)
+
+    def test_missing_proof_fails(self):
+        mapping, _ = ss.resolve_plane("workspace", start=self.child)
+        ok, reason = ss.verify_proof(mapping)
+        self.assertFalse(ok)
+        self.assertIn("no proof", reason)
+
+    def test_tampered_mapping_fails(self):
+        mapping, _ = ss.resolve_plane("workspace", start=self.child)
+        path = ss.write_proof(mapping)
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        data["commit_repo"] = str(self.child)   # redirect the commit target
+        Path(path).write_text(json.dumps(data), encoding="utf-8")
+        ok, reason = ss.verify_proof(mapping)
+        self.assertFalse(ok)
+
+
+class CliCases(ScopeFixture):
+    def _run(self, argv):
+        import contextlib
+        import io
+        out = io.StringIO()
+        err = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ss.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_resolve_cli_json(self):
+        rc, out, _ = self._run(["save_scope.py", "resolve",
+                                "--scope", "workspace",
+                                "--start", str(self.child)])
+        self.assertEqual(rc, 0)
+        mapping = json.loads(out)
+        self.assertEqual(mapping["plane_base"], str(self.ws))
+
+    def test_resolve_cli_failure_typed(self):
+        lone = self.tmp / "home" / "solo"
+        lone.mkdir(parents=True)
+        rc, out, _ = self._run(["save_scope.py", "resolve",
+                                "--scope", "workspace",
+                                "--start", str(lone)])
+        self.assertEqual(rc, 1)
+        verdict = json.loads(out)
+        self.assertEqual(verdict["errors"][0]["code"], "no_workspace")
+
+    def test_proof_write_and_verify_cli(self):
+        rc, out, _ = self._run(["save_scope.py", "write-proof",
+                                "--scope", "workspace",
+                                "--start", str(self.child)])
+        self.assertEqual(rc, 0)
+        rc, _, _ = self._run(["save_scope.py", "verify",
+                              "--scope", "workspace",
+                              "--start", str(self.child)])
+        self.assertEqual(rc, 0)
+
+    def test_verify_cli_fails_after_mutation(self):
+        self._run(["save_scope.py", "write-proof", "--scope", "workspace",
+                   "--start", str(self.child)])
+        (self.ws / "Memory" / "activeContext.md").write_text(
+            "# mutated\n", encoding="utf-8")
+        rc, _, _ = self._run(["save_scope.py", "verify",
+                              "--scope", "workspace",
+                              "--start", str(self.child)])
+        self.assertEqual(rc, 1)
+
+    def test_usage_error(self):
+        rc, _, err = self._run(["save_scope.py", "bogus"])
+        self.assertEqual(rc, 2)
+        self.assertIn("usage", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -357,6 +357,129 @@ else
 fi
 
 # ============================================================================
+# Test 9c: save-commit-gate — golden corpus + workspace plane selection
+# (workspace v1, issue #36). The golden half pins TODAY's no-workspace
+# behavior and must be green before AND after the gate learns planes; the
+# ws_* half pins the state-based selection from the ratified design memo.
+# ============================================================================
+echo -n "Test 9c: save-commit-gate golden corpus + plane selection... "
+G9C_OK=1; G9C_WHY=""
+chk9c() { [[ "$2" == "$3" ]] || { G9C_OK=0; G9C_WHY="$G9C_WHY $1(got='$2' want='$3')"; }; }
+
+GATE="$REPO_ROOT/plugins/session/hooks/handlers/save-commit-gate.sh"
+SS_TOOL="$REPO_ROOT/plugins/session/tools/save_scope.py"
+G9C="$(mktemp -d)"
+G9C_HOME="$G9C/home"
+mkdir -p "$G9C_HOME"
+
+g9c_git() { git -c user.name=t -c user.email=t@t -c init.defaultBranch=master "$@" >/dev/null 2>&1; }
+g9c_payload() { jq -cn --arg c "$1" --arg d "$2" '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}'; }
+g9c_decision() {  # payload [extra env pairs...]
+    local payload="$1"; shift
+    local out rc=0
+    out="$(printf '%s' "$payload" | env -u ASHA_HARNESS -u CLAUDE_PROJECT_DIR \
+        HOME="$G9C_HOME" "$@" bash "$GATE" 2>/dev/null)" || rc=$?
+    if [[ $rc -eq 2 ]]; then echo deny
+    elif [[ -n "$out" ]]; then
+        printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // "allow"' 2>/dev/null || echo allow
+    else echo allow; fi
+}
+
+# --- golden fixture: plain project, NO workspace anywhere above ---
+P="$G9C_HOME/proj"
+mkdir -p "$P/Memory" "$P/Work/markers"
+echo "# ctx" > "$P/Memory/activeContext.md"
+g9c_git init "$P"
+( cd "$P" && echo base > base.txt && g9c_git add base.txt && g9c_git commit -m init )
+g9c_ac_sha() { sha256sum "$1/Memory/activeContext.md" | cut -d' ' -f1; }
+
+chk9c g_clean   "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" allow
+( cd "$P" && echo o > other.txt && g9c_git add other.txt )
+chk9c g_nonmem  "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" allow
+( cd "$P" && g9c_git reset )
+chk9c g_headref "$(g9c_decision "$(g9c_payload 'git add Memory/ && git commit -m x' "$P")")" deny
+( cd "$P" && echo n > Memory/note.md && g9c_git add Memory/note.md )
+chk9c g_staged_nomarker "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" deny
+printf '{"ac_sha256":"%s"}' "$(g9c_ac_sha "$P")" > "$P/Work/markers/save-gates-ok"
+chk9c g_valid_marker "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" allow
+printf '{"ac_sha256":"deadbeef"}' > "$P/Work/markers/save-gates-ok"
+chk9c g_stale_marker "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" deny
+[[ ! -f "$P/Work/markers/save-gates-ok" ]] && g_del=gone || g_del=present
+chk9c g_stale_deleted "$g_del" gone
+touch "$P/Work/markers/silence"
+chk9c g_silence "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")")" deny
+rm -f "$P/Work/markers/silence"
+( cd "$P" && g9c_git reset )
+chk9c g_msg_mention "$(g9c_decision "$(g9c_payload 'git commit -m "docs: Memory/ notes"' "$P")")" allow
+P2="$G9C_HOME/proj2"; mkdir -p "$P2/Memory"
+g9c_git init "$P2"
+( cd "$P2" && echo n > Memory/first.md && g9c_git add Memory/first.md )
+chk9c g_first_init "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P2")")" allow
+( cd "$P" && g9c_git add Memory/note.md )
+chk9c g_payload_cwd_wins "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")" CLAUDE_PROJECT_DIR="$G9C_HOME")" deny
+chk9c g_override "$(g9c_decision "$(g9c_payload 'git commit -m x' "$P")" ASHA_ALLOW_UNGATED_MEMORY_COMMIT=1)" allow
+( cd "$P" && g9c_git reset )
+
+# --- workspace fixture: sgr = ws root, one child repo ---
+WSR="$G9C_HOME/Code/ws"
+mkdir -p "$WSR/.asha" "$WSR/Memory" "$WSR/Work/markers"
+printf '{"version":1,"workspace_name":"ws","repositories":[{"path":"child"}]}' > "$WSR/.asha/workspace.json"
+echo "# ws ctx" > "$WSR/Memory/activeContext.md"
+g9c_git init "$WSR"
+( cd "$WSR" && echo b > b.txt && g9c_git add b.txt && g9c_git commit -m init )
+CH="$WSR/child"
+mkdir -p "$CH/Memory" "$CH/Work/markers"
+echo "# child ctx" > "$CH/Memory/activeContext.md"
+g9c_git init "$CH"
+( cd "$CH" && echo b > b.txt && g9c_git add b.txt && g9c_git commit -m init )
+
+# ws plane staged, no ws proof -> deny
+( cd "$WSR" && echo w > Memory/w.md && g9c_git add Memory/w.md )
+chk9c ws_staged_noproof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x" "$CH")")" deny
+# valid v2 proof -> allow
+env HOME="$G9C_HOME" python3 "$SS_TOOL" write-proof --scope workspace --start "$CH" >/dev/null 2>&1
+chk9c ws_staged_proof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x" "$CH")")" allow
+# child plane keeps working under a workspace via its legacy marker
+( cd "$WSR" && g9c_git reset )
+( cd "$CH" && echo c > Memory/c.md && g9c_git add Memory/c.md )
+printf '{"ac_sha256":"%s"}' "$(g9c_ac_sha "$CH")" > "$CH/Work/markers/save-gates-ok"
+chk9c ws_child_legacy "$(g9c_decision "$(g9c_payload 'git commit -m x' "$CH")")" allow
+# cross-plane laundering: ONLY the ws proof present, child Memory staged -> deny
+rm -f "$CH/Work/markers/save-gates-ok"
+chk9c ws_cross_plane "$(g9c_decision "$(g9c_payload 'git commit -m x' "$CH")")" deny
+# both planes staged -> ambiguous -> deny
+( cd "$WSR" && g9c_git add Memory/w.md )
+printf '{"ac_sha256":"%s"}' "$(g9c_ac_sha "$CH")" > "$CH/Work/markers/save-gates-ok"
+chk9c ws_ambiguous "$(g9c_decision "$(g9c_payload 'git commit -m x' "$CH")")" deny
+( cd "$WSR" && g9c_git reset )
+( cd "$CH" && g9c_git reset )
+# invalid manifest + Memory signal -> fail closed
+printf '{"version":9}' > "$WSR/.asha/workspace.json"
+( cd "$CH" && g9c_git add Memory/c.md )
+chk9c ws_invalid_manifest "$(g9c_decision "$(g9c_payload 'git commit -m x' "$CH")")" deny
+printf '{"version":1,"workspace_name":"ws","repositories":[{"path":"child"}]}' > "$WSR/.asha/workspace.json"
+# python3 unavailable under a workspace with a Memory signal -> fail closed
+G9C_BIN="$G9C/bin"; mkdir -p "$G9C_BIN"
+for t in git jq grep sha256sum cut rm dirname cat sed mktemp date; do
+    command -v "$t" >/dev/null 2>&1 && ln -s "$(command -v "$t")" "$G9C_BIN/$t"
+done
+out="$(printf '%s' "$(g9c_payload 'git commit -m x' "$CH")" | env -u ASHA_HARNESS -u CLAUDE_PROJECT_DIR \
+    HOME="$G9C_HOME" PATH="$G9C_BIN" /bin/bash "$GATE" 2>/dev/null)" && ws_nopy_rc=0 || ws_nopy_rc=$?
+[[ $ws_nopy_rc -eq 2 ]] && ws_nopy=deny || ws_nopy=allow
+chk9c ws_no_python "$ws_nopy" deny
+( cd "$CH" && g9c_git reset )
+
+rm -rf "$G9C"
+if [[ $G9C_OK -eq 1 ]]; then
+    echo -e "${GREEN}PASS${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC}"
+    echo "  gate-pin mismatch:$G9C_WHY"
+    FAILED=$((FAILED + 1))
+fi
+
+# ============================================================================
 # Test 10: is_asha_initialized function
 # ============================================================================
 echo -n "Test 10: is_asha_initialized correctly detects initialization... "

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -439,6 +439,8 @@ chk9c ws_staged_noproof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x"
 # valid v2 proof -> allow
 env HOME="$G9C_HOME" python3 "$SS_TOOL" write-proof --scope workspace --start "$CH" >/dev/null 2>&1
 chk9c ws_staged_proof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x" "$CH")")" allow
+# consume-on-use: the SAME commit again without a fresh proof denies
+chk9c ws_proof_consumed "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x" "$CH")")" deny
 # child plane keeps working under a workspace via its legacy marker
 ( cd "$WSR" && g9c_git reset )
 ( cd "$CH" && echo c > Memory/c.md && g9c_git add Memory/c.md )
@@ -468,6 +470,52 @@ out="$(printf '%s' "$(g9c_payload 'git commit -m x' "$CH")" | env -u ASHA_HARNES
 [[ $ws_nopy_rc -eq 2 ]] && ws_nopy=deny || ws_nopy=allow
 chk9c ws_no_python "$ws_nopy" deny
 ( cd "$CH" && g9c_git reset )
+
+# --- pass-2 pins (PR #38 review): commit -a, pathspec, compound laundering,
+# broken-resolver ws staging, non-regular manifest nodes, unset HOME ---
+# commit -a picks up dirty TRACKED plane memory: gate must require proof.
+( cd "$WSR" && g9c_git add Memory/activeContext.md && g9c_git commit -m mem )
+echo "changed" >> "$WSR/Memory/activeContext.md"
+chk9c ws_commit_a_noproof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -am x" "$CH")")" deny
+env HOME="$G9C_HOME" python3 "$SS_TOOL" write-proof --scope workspace --start "$CH" >/dev/null 2>&1
+chk9c ws_commit_a_proof "$(g9c_decision "$(g9c_payload "git -C $WSR commit -am x" "$CH")")" allow
+( cd "$WSR" && g9c_git checkout -- Memory/activeContext.md )
+# pathspec commit of a dirty child memory file without a child marker
+( cd "$CH" && g9c_git add Memory/activeContext.md && g9c_git commit -m mem )
+echo "changed" >> "$CH/Memory/activeContext.md"
+rm -f "$CH/Work/markers/save-gates-ok"
+chk9c ws_pathspec_deny "$(g9c_decision "$(g9c_payload 'git commit Memory/activeContext.md -m x' "$CH")")" deny
+# a commit MESSAGE mentioning Memory/ with clean planes stays allowed
+( cd "$CH" && g9c_git checkout -- Memory/activeContext.md )
+chk9c ws_msg_clean "$(g9c_decision "$(g9c_payload 'git commit -m "docs: Memory/ notes"' "$CH")")" allow
+# compound laundering: valid CHILD marker but the ws plane has an untracked
+# memory file the add would stage -> deny (was: allowed via cwd attribution)
+printf '{"ac_sha256":"%s"}' "$(g9c_ac_sha "$CH")" > "$CH/Work/markers/save-gates-ok"
+echo w2 > "$WSR/Memory/w2.md"
+chk9c ws_compound_launder "$(g9c_decision "$(g9c_payload "git -C $WSR add Memory/ && git -C $WSR commit -m x" "$CH")")" deny
+# same compound WITH the ws proof and a memory-clean child -> allow
+rm -f "$CH/Work/markers/save-gates-ok" "$CH/Memory/c.md"
+env HOME="$G9C_HOME" python3 "$SS_TOOL" write-proof --scope workspace --start "$CH" >/dev/null 2>&1
+chk9c ws_compound_ok "$(g9c_decision "$(g9c_payload "git -C $WSR add Memory/ && git -C $WSR commit -m x" "$CH")")" allow
+rm -f "$WSR/Memory/w2.md"
+# broken resolver + WS-plane staging (child clean) must still fail closed
+printf '{"version":9}' > "$WSR/.asha/workspace.json"
+( cd "$WSR" && echo w3 > Memory/w3.md && g9c_git add Memory/w3.md )
+chk9c ws_broken_ws_staged "$(g9c_decision "$(g9c_payload "git -C $WSR commit -m x" "$CH")")" deny
+( cd "$WSR" && g9c_git reset )
+rm -f "$WSR/Memory/w3.md"
+printf '{"version":1,"workspace_name":"ws","repositories":[{"path":"child"}]}' > "$WSR/.asha/workspace.json"
+# a manifest path that is a DIRECTORY routes to fail-closed, not legacy
+WS2="$G9C_HOME/Code/ws2"
+mkdir -p "$WS2/.asha/workspace.json" "$WS2/child2/Memory" "$WS2/child2/Work/markers"
+echo "# c2" > "$WS2/child2/Memory/activeContext.md"
+g9c_git init "$WS2/child2"
+( cd "$WS2/child2" && echo n > Memory/n.md && g9c_git add Memory/n.md )
+chk9c ws_nonregular_manifest "$(g9c_decision "$(g9c_payload 'git commit -m x' "$WS2/child2")")" deny
+# unset HOME: silent and allowing for a clean non-workspace commit
+he="$(printf '%s' "$(g9c_payload 'git commit -m x' "$P")" | env -u ASHA_HARNESS -u CLAUDE_PROJECT_DIR -u HOME \
+    bash "$GATE" 2>&1 >/dev/null)" || true
+chk9c home_unset_quiet "$he" ""
 
 rm -rf "$G9C"
 if [[ $G9C_OK -eq 1 ]]; then


### PR DESCRIPTION
Closes #36. The guardrail-grade increment: `/save --scope repo|workspace|none`, the writer-side proof seam, and the plane-aware commit gate — built exactly to the design memo ratified in #36 (state-based selection, never command parsing).

## What changed

- **`tools/save_scope.py`** (new) — the primary enforcement seam: `resolve_plane` (three distinct values: `plane_base`/`memory_root`/`commit_repo`), versioned structured **proof** binding mapping + activeContext sha, `verify_proof` rejecting wrong-plane/tampered/stale proofs. Fails closed without a valid manifest or a real git worktree at `shared_git_root`.
- **`save-commit-gate.sh`** — plane selection by **repository state**: a pure-bash existence walk (in the shared resolver lib) keeps the no-manifest path **byte-identical at zero python cost** — pinned by a 12-case golden corpus that was green against the OLD gate before the rewrite. Manifest-present-but-unvalidatable **denies** on any Memory signal (the in-file fail-open contract stays for legacy internals — in-file contracts outrank defaults). Both planes staged → deny ambiguous. Each plane's proof satisfies only itself (cross-plane laundering pinned).
- **`save-preflight-stop.sh`** — v2 locators route to the structural proof with logs under the plane; attempt-marker rewrites preserve routing fields (dropping them would misroute attempt 2). Legacy markers untouched.
- **`save.md`** — scope routing; `--scope workspace` stages ONLY the plane's memory root, commits in `commit_repo`, pushes via push_retry against `commit_repo` (never payload cwd).

## Memo pin categories covered

Golden equivalence (12), workspace proof selection incl. cross-plane + ambiguity (7 in Test 9c), detector failures (invalid manifest, absent python → fail closed, probed via a PATH shim), writer integration (17 save_scope tests: mapping, proof round-trip, tamper, stale, wrong-plane). Shell-form independence is structural — state decides, no spelling parsed. Named residuals from the memo (activeContext-only binding, non-atomic check-to-commit window, cwd-tied locator) documented in #36.

## Test plan
- [x] Test 9c: 19 pins (golden green pre+post; workspace pins RED→GREEN)
- [x] 17 save_scope unit tests (RED before module)
- [x] Full suite **14/14**; validate-versions 5/5 (session 1.17.0)
- [ ] Codex adversarial pass before leaving draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)